### PR TITLE
New methods for dislocation creep laws and fix test_DislocationCreep.jl

### DIFF
--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -70,6 +70,14 @@ function computeCreepLaw_EpsII(TauII, a::DislocationCreep, p::CreepLawVariables)
     @unpack_val n,r,A,E,V,R = a
     @unpack_val P,T,f       = p
     
+    FT, FE = CorrectionFactor(a)
+   
+    return A*(TauII*FT)^n*f^r*exp(-(E + P*V)/(R*T))/FE
+end
+
+function computeCreepLaw_EpsII(TauII, a::DislocationCreep, P::_R, T::_R, f::_R) where _R<:Real
+    @unpack_val n,r,A,E,V,R = a
+    
     FT, FE = CorrectionFactor(a);    
    
     return A*(TauII*FT)^n*f^r*exp(-(E + P*V)/(R*T))/FE; 
@@ -81,10 +89,22 @@ function computeCreepLaw_TauII(EpsII, a::DislocationCreep, p::CreepLawVariables)
     @unpack_val n,r,A,E,V,R = a
     @unpack_val P,T,f       = p
 
-    FT, FE = CorrectionFactor(a);    
+    FT, FE = CorrectionFactor(a)    
 
     return A^(-1/n)*(EpsII*FE)^(1/n)*f^(-r/n)*exp((E + P*V)/(n * R*T))/FT;
 end
+
+
+# EpsII .= A.*(TauII.*FT).^n.*f.^r.*exp.(-(E.+P.*V)./(R.*T))./FE; Once we have a 
+# All inputs must be non-dimensionalized (or converted to consistent units) GeoUnits
+function computeCreepLaw_TauII(EpsII, a::DislocationCreep, P::_R, T::_R, f::_R) where _R<:Real
+    @unpack_val n,r,A,E,V,R = a
+
+    FT, FE = CorrectionFactor(a);    
+
+    return A^(-1/n)*(EpsII*FE)^(1/n)*f^(-r/n)*exp((E + P*V)/(n * R*T))/FT
+end
+
 
 # Print info 
 function show(io::IO, g::DislocationCreep)  

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -158,81 +158,31 @@ Base.length(v::GeoUnit)         =   length(v.val)
 Base.size(v::GeoUnit)           =   size(v.val)
 Base.getindex(A::GeoUnit{T,U}, inds::Vararg{Int,N}) where {T,U,N} = A.val[inds...]
 
-# Multiply with numnber
-Base.:*(x::GeoUnit, y::Number)  =   x.val*y
-Base.:+(x::GeoUnit, y::Number)  =   x.val+y
-Base.:/(x::GeoUnit, y::Number)  =   x.val/y
-Base.:-(x::GeoUnit, y::Number)  =   x.val-y
-
-Base.:*(x::Number, y::GeoUnit)  = y.val*x
-Base.:+(x::Number, y::GeoUnit)  = y.val+x
-Base.:/(x::Number, y::GeoUnit)  = x/y.val
-Base.:-(x::Number, y::GeoUnit)  = x-y.val
-
-# Multiplying a GeoUnit with another one, returns a GeoUnit
-Base.:+(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) + Value(y)) 
-Base.:/(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) / Value(y)) 
-Base.:*(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) * Value(y))  
-Base.:-(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) - Value(y)) 
-Base.:^(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) ^ Value(y)) 
-
-Base.:*(x::GeoUnit, y::Quantity)   = UnitValue(x).*y
-Base.:/(x::GeoUnit, y::Quantity)   = UnitValue(x)./y
-Base.:+(x::GeoUnit, y::Quantity)   = UnitValue(x) .+ y
-Base.:-(x::GeoUnit, y::Quantity)   = UnitValue(x) .- y
-
-Base.:*(x::Quantity, y::GeoUnit)   = x.*UnitValue(y)
-Base.:/(x::Quantity, y::GeoUnit)   = x./UnitValue(y)
-Base.:+(x::Quantity, y::GeoUnit)   = x .+ UnitValue(y)
-Base.:-(x::Quantity, y::GeoUnit)   = x .- UnitValue(y) 
-
-# If we multiply a GeoUnit with an abstract array, we only return values, not units (use GeoUnits for that)
-Base.:*(x::GeoUnit, y::AbstractArray)   = NumValue(x) .* y
-Base.:/(x::GeoUnit, y::AbstractArray)   = broadcast(/,NumValue(x), y) 
-Base.:+(x::GeoUnit, y::AbstractArray)   = broadcast(+,NumValue(x), y) 
-Base.:-(x::GeoUnit, y::AbstractArray)   = broadcast(-,NumValue(x), y) 
-
-Base.:*(y::AbstractArray, x::GeoUnit)   = broadcast(*,y, NumValue(x)) 
-Base.:/(y::AbstractArray, x::GeoUnit)   = broadcast(/,y, NumValue(x)) 
-Base.:+(y::AbstractArray, x::GeoUnit)   = broadcast(+,y, NumValue(x)) 
-Base.:-(y::AbstractArray, x::GeoUnit)   = broadcast(-,y, NumValue(x)) 
-
-Base.:*(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(*,Value(x), y) 
-Base.:/(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(/,Value(x), y) 
-Base.:+(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(+,Value(x), y) 
-Base.:-(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(-,Value(x), y) 
-
-Base.:*(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(*,y, Value(x)) 
-Base.:/(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(/,y, Value(x)) 
-Base.:+(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(+,y, Value(x)) 
-Base.:-(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(-,y, Value(x)) 
-
-#for op in (+, *, -, ^,/)
+for op in (:*, :+, :/, :-)
+    eval(quote
+        # Basic scalar operations
+        Base.$op(x::GeoUnit, y::Number) = $op(x.val, y)
+        Base.$op(x::Number, y::GeoUnit) = $op(x,y.val)
+        # # Multiplying a GeoUnit with another one, returns a GeoUnit 
+        Base.$op(x::GeoUnit, y::GeoUnit) = GeoUnit($op(Value(x),Value(y)))
+        Base.$op(x::GeoUnit, y::Quantity) = broadcast($op, UnitValue(x), y)
+        Base.$op(x::Quantity, y::GeoUnit) = broadcast($op, x, UnitValue(y))
+        # If we multiply a GeoUnit with an abstract array, we only return values, not units (use GeoUnits for that)
+        Base.$op(x::GeoUnit, y::AbstractArray) = broadcast($op, NumValue(x), y) 
+        Base.$op(x::AbstractArray, y::GeoUnit) = broadcast($op, x, NumValue(y)) 
+        Base.$op(x::GeoUnit, y::AbstractArray{<:Quantity}) = broadcast($op, Value(x), y) 
+        Base.$op(x::AbstractArray{<:Quantity}, y::GeoUnit) = broadcast($op, x, Value(y)) 
+        Base.broadcasted(::typeof($op), A::GeoUnit, B::AbstractArray) = broadcast($op, NumValue(A), B)
+        Base.broadcasted(::typeof($op), A::AbstractArray, B::GeoUnit) = broadcast($op, A, NumValue(B))
+        Base.broadcasted(::typeof($op), A::GeoUnit, B::AbstractArray{<:Quantity}) = broadcast($op, Value(A), B)
+        Base.broadcasted(::typeof($op), B::AbstractArray{<:Quantity}, A::GeoUnit) = broadcast($op, A, Value(B))
+    end)
+end
  
-# Broadcasting
-Base.broadcasted(::typeof(+), A::GeoUnit,       B::AbstractArray)           = broadcast(+, NumValue(A), B)
-Base.broadcasted(::typeof(*), A::GeoUnit,       B::AbstractArray)           = broadcast(*, NumValue(A), B)
-Base.broadcasted(::typeof(-), A::GeoUnit,       B::AbstractArray)           = broadcast(-, NumValue(A), B)
-Base.broadcasted(::typeof(/), A::GeoUnit,       B::AbstractArray)           = broadcast(/, NumValue(A), B)
+# exponentials
 Base.broadcasted(::typeof(^), A::GeoUnit,       B::AbstractArray)           = broadcast(^, NumValue(A), B)
-
-    
-Base.broadcasted(::typeof(+), A::AbstractArray, B::GeoUnit)                 = broadcast(+, A, NumValue(B))
-Base.broadcasted(::typeof(*), A::AbstractArray, B::GeoUnit)                 = broadcast(*, A, NumValue(B))
-Base.broadcasted(::typeof(-), A::AbstractArray, B::GeoUnit)                 = broadcast(-, A, NumValue(B))
-Base.broadcasted(::typeof(/), A::AbstractArray, B::GeoUnit)                 = broadcast(/, A, NumValue(B))
 Base.broadcasted(::typeof(^), A::AbstractArray, B::GeoUnit)                 = broadcast(^, A, NumValue(B))
-    
-Base.broadcasted(::typeof(+), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(+, Value(A), B)
-Base.broadcasted(::typeof(*), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(*, Value(A), B)
-Base.broadcasted(::typeof(-), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(-, Value(A), B)
-Base.broadcasted(::typeof(/), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(/, Value(A), B)
 Base.broadcasted(::typeof(^), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(^, Value(A), B)
-    
-Base.broadcasted(::typeof(+), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(+, A, Value(B))
-Base.broadcasted(::typeof(*), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(*, A, Value(B))
-Base.broadcasted(::typeof(-), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(-, A, Value(B))
-Base.broadcasted(::typeof(/), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(/, A, Value(B))
 Base.broadcasted(::typeof(^), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(^, A, Value(B))
 
 Base.getindex(x::GeoUnit, i::Int64, j::Int64, k::Int64) = GeoUnit(x.val[i,j,k]*x.unit)

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -158,31 +158,81 @@ Base.length(v::GeoUnit)         =   length(v.val)
 Base.size(v::GeoUnit)           =   size(v.val)
 Base.getindex(A::GeoUnit{T,U}, inds::Vararg{Int,N}) where {T,U,N} = A.val[inds...]
 
-for op in (:*, :+, :/, :-)
-    eval(quote
-        # Basic scalar operations
-        Base.$op(x::GeoUnit, y::Number) = $op(x.val, y)
-        Base.$op(x::Number, y::GeoUnit) = $op(x,y.val)
-        # # Multiplying a GeoUnit with another one, returns a GeoUnit 
-        Base.$op(x::GeoUnit, y::GeoUnit) = GeoUnit($op(Value(x),Value(y)))
-        Base.$op(x::GeoUnit, y::Quantity) = broadcast($op, UnitValue(x), y)
-        Base.$op(x::Quantity, y::GeoUnit) = broadcast($op, x, UnitValue(y))
-        # If we multiply a GeoUnit with an abstract array, we only return values, not units (use GeoUnits for that)
-        Base.$op(x::GeoUnit, y::AbstractArray) = broadcast($op, NumValue(x), y) 
-        Base.$op(x::AbstractArray, y::GeoUnit) = broadcast($op, x, NumValue(y)) 
-        Base.$op(x::GeoUnit, y::AbstractArray{<:Quantity}) = broadcast($op, Value(x), y) 
-        Base.$op(x::AbstractArray{<:Quantity}, y::GeoUnit) = broadcast($op, x, Value(y)) 
-        Base.broadcasted(::typeof($op), A::GeoUnit, B::AbstractArray) = broadcast($op, NumValue(A), B)
-        Base.broadcasted(::typeof($op), A::AbstractArray, B::GeoUnit) = broadcast($op, A, NumValue(B))
-        Base.broadcasted(::typeof($op), A::GeoUnit, B::AbstractArray{<:Quantity}) = broadcast($op, Value(A), B)
-        Base.broadcasted(::typeof($op), B::AbstractArray{<:Quantity}, A::GeoUnit) = broadcast($op, A, Value(B))
-    end)
-end
+# Multiply with numnber
+Base.:*(x::GeoUnit, y::Number)  =   x.val*y
+Base.:+(x::GeoUnit, y::Number)  =   x.val+y
+Base.:/(x::GeoUnit, y::Number)  =   x.val/y
+Base.:-(x::GeoUnit, y::Number)  =   x.val-y
+
+Base.:*(x::Number, y::GeoUnit)  = y.val*x
+Base.:+(x::Number, y::GeoUnit)  = y.val+x
+Base.:/(x::Number, y::GeoUnit)  = x/y.val
+Base.:-(x::Number, y::GeoUnit)  = x-y.val
+
+# Multiplying a GeoUnit with another one, returns a GeoUnit
+Base.:+(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) + Value(y)) 
+Base.:/(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) / Value(y)) 
+Base.:*(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) * Value(y))  
+Base.:-(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) - Value(y)) 
+Base.:^(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2} = GeoUnit(Value(x) ^ Value(y)) 
+
+Base.:*(x::GeoUnit, y::Quantity)   = UnitValue(x).*y
+Base.:/(x::GeoUnit, y::Quantity)   = UnitValue(x)./y
+Base.:+(x::GeoUnit, y::Quantity)   = UnitValue(x) .+ y
+Base.:-(x::GeoUnit, y::Quantity)   = UnitValue(x) .- y
+
+Base.:*(x::Quantity, y::GeoUnit)   = x.*UnitValue(y)
+Base.:/(x::Quantity, y::GeoUnit)   = x./UnitValue(y)
+Base.:+(x::Quantity, y::GeoUnit)   = x .+ UnitValue(y)
+Base.:-(x::Quantity, y::GeoUnit)   = x .- UnitValue(y) 
+
+# If we multiply a GeoUnit with an abstract array, we only return values, not units (use GeoUnits for that)
+Base.:*(x::GeoUnit, y::AbstractArray)   = NumValue(x) .* y
+Base.:/(x::GeoUnit, y::AbstractArray)   = broadcast(/,NumValue(x), y) 
+Base.:+(x::GeoUnit, y::AbstractArray)   = broadcast(+,NumValue(x), y) 
+Base.:-(x::GeoUnit, y::AbstractArray)   = broadcast(-,NumValue(x), y) 
+
+Base.:*(y::AbstractArray, x::GeoUnit)   = broadcast(*,y, NumValue(x)) 
+Base.:/(y::AbstractArray, x::GeoUnit)   = broadcast(/,y, NumValue(x)) 
+Base.:+(y::AbstractArray, x::GeoUnit)   = broadcast(+,y, NumValue(x)) 
+Base.:-(y::AbstractArray, x::GeoUnit)   = broadcast(-,y, NumValue(x)) 
+
+Base.:*(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(*,Value(x), y) 
+Base.:/(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(/,Value(x), y) 
+Base.:+(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(+,Value(x), y) 
+Base.:-(x::GeoUnit, y::AbstractArray{<:Quantity})   = broadcast(-,Value(x), y) 
+
+Base.:*(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(*,y, Value(x)) 
+Base.:/(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(/,y, Value(x)) 
+Base.:+(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(+,y, Value(x)) 
+Base.:-(y::AbstractArray{<:Quantity}, x::GeoUnit)   = broadcast(-,y, Value(x)) 
+
+#for op in (+, *, -, ^,/)
  
-# exponentials
+# Broadcasting
+Base.broadcasted(::typeof(+), A::GeoUnit,       B::AbstractArray)           = broadcast(+, NumValue(A), B)
+Base.broadcasted(::typeof(*), A::GeoUnit,       B::AbstractArray)           = broadcast(*, NumValue(A), B)
+Base.broadcasted(::typeof(-), A::GeoUnit,       B::AbstractArray)           = broadcast(-, NumValue(A), B)
+Base.broadcasted(::typeof(/), A::GeoUnit,       B::AbstractArray)           = broadcast(/, NumValue(A), B)
 Base.broadcasted(::typeof(^), A::GeoUnit,       B::AbstractArray)           = broadcast(^, NumValue(A), B)
+
+    
+Base.broadcasted(::typeof(+), A::AbstractArray, B::GeoUnit)                 = broadcast(+, A, NumValue(B))
+Base.broadcasted(::typeof(*), A::AbstractArray, B::GeoUnit)                 = broadcast(*, A, NumValue(B))
+Base.broadcasted(::typeof(-), A::AbstractArray, B::GeoUnit)                 = broadcast(-, A, NumValue(B))
+Base.broadcasted(::typeof(/), A::AbstractArray, B::GeoUnit)                 = broadcast(/, A, NumValue(B))
 Base.broadcasted(::typeof(^), A::AbstractArray, B::GeoUnit)                 = broadcast(^, A, NumValue(B))
+    
+Base.broadcasted(::typeof(+), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(+, Value(A), B)
+Base.broadcasted(::typeof(*), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(*, Value(A), B)
+Base.broadcasted(::typeof(-), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(-, Value(A), B)
+Base.broadcasted(::typeof(/), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(/, Value(A), B)
 Base.broadcasted(::typeof(^), A::GeoUnit,    B::AbstractArray{<:Quantity})  = broadcast(^, Value(A), B)
+    
+Base.broadcasted(::typeof(+), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(+, A, Value(B))
+Base.broadcasted(::typeof(*), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(*, A, Value(B))
+Base.broadcasted(::typeof(-), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(-, A, Value(B))
+Base.broadcasted(::typeof(/), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(/, A, Value(B))
 Base.broadcasted(::typeof(^), A::AbstractArray{<:Quantity}, B::GeoUnit)     = broadcast(^, A, Value(B))
 
 Base.getindex(x::GeoUnit, i::Int64, j::Int64, k::Int64) = GeoUnit(x.val[i,j,k]*x.unit)

--- a/test/test_DislocationCreep.jl
+++ b/test/test_DislocationCreep.jl
@@ -3,51 +3,53 @@ using GeoParams
 
 @testset "DislocationCreepLaws" begin
 
-# This tests the MaterialParameters structure
-CharUnits_GEO   =   GEO_units(viscosity=1e19, length=1000km);
-                
-# Define a linear viscous creep law ---------------------------------
-x1      =   DislocationCreep()
-@test isbits(x1)
-@test x1.n.val == 1.0
-@test x1.A.val == 1.5MPa^-1*s^-1
+    # This tests the MaterialParameters structure
+    CharUnits_GEO = GEO_units(; viscosity=1e19, length=1000km)
 
-x2      =   DislocationCreep(n=3)
-@test x2.A.val == 1.5MPa^-3*s^-1
+    # Define a linear viscous creep law ---------------------------------
+    x1 = DislocationCreep()
+    @test isbits(x1)
+    @test x1.n.val == 1.0
+    @test x1.A.val == 1.5
 
+    x2 = DislocationCreep(; n=3)
+    @test x2.A.val == 1.5
 
-
-# perform a computation with the dislocation creep laws 
+    # perform a computation with the dislocation creep laws 
     # Calculate EpsII, using a set of pre-defined values
-CharDim = GEO_units()
-EpsII  = GeoUnit(0s^-1)
-        Nondimensionalize!(EpsII,CharDim)
-TauII   = GeoUnit(100MPa)
-        Nondimensionalize!(TauII,CharDim)
-P       = GeoUnit(100MPa)
-        Nondimensionalize!(P,CharDim)
-T       = GeoUnit(500C)
-        Nondimensionalize!(T,CharDim)
-f       = GeoUnit(50MPa)
-        Nondimensionalize!(f,CharDim)
-p       = CreepLawVariables(P=P,T=T,f=f)
-Phase   = SetMaterialParams(Name="Viscous Matrix", Phase=2,
-                                     Density   = ConstantDensity(),
-                                     CreepLaws = DislocationCreep(n=3NoUnits, r=1NoUnits), CharDim = CharDim)
-EpsII.val = computeCreepLaw_EpsII(TauII,Phase.CreepLaws[1],p)
-@test EpsII.val  ≈ 2.1263214994323903e-11 rtol = 1e-8
+    CharDim = GEO_units()
+    EpsII = GeoUnit(0s^-1)
+    EpsII = nondimensionalize(EpsII, CharDim)
+    TauII = GeoUnit(100MPa)
+    TauII = nondimensionalize(TauII, CharDim)
+    P = GeoUnit(100MPa)
+    P = nondimensionalize(P, CharDim)
+    T = GeoUnit(500C)
+    T = nondimensionalize(T, CharDim)
+    f = GeoUnit(50MPa)
+    f = nondimensionalize(f, CharDim)
+    p = CreepLawVariables(; P=P, T=T, f=f)
+    Phase = SetMaterialParams(;
+        Name="Viscous Matrix",
+        Phase=2,
+        Density=ConstantDensity(),
+        CreepLaws=DislocationCreep(; n=3NoUnits, r=1NoUnits),
+        CharDim=CharDim,
+    )
+    εII = computeCreepLaw_EpsII(TauII, Phase.CreepLaws[1], p)
+    @test εII ≈ 2.1263214994323903e-11 rtol = 1e-8
+
+    @test εII == computeCreepLaw_EpsII(TauII, Phase.CreepLaws[1], P.val, T.val, f.val)
 
     # Check that once inverted, we get back the TauII that we used to calculate EpsII
-NewTau = computeCreepLaw_EpsII(EpsII,Phase.CreepLaws[1],p)
-@test NewTau ≈ TauII.val 
+    NewTau = computeCreepLaw_TauII(εII, Phase.CreepLaws[1], p)
+    @test NewTau ≈ TauII.val
+    @test NewTau == computeCreepLaw_TauII(εII, Phase.CreepLaws[1], P.val, T.val, f.val)
 
+    # Given stress
+    #@test computeCreepLaw_EpsII(1e6Pa, x1, CreepLawParams())==5e-13/s                # dimensional input       
 
-# Given stress
-#@test computeCreepLaw_EpsII(1e6Pa, x1, CreepLawParams())==5e-13/s                # dimensional input       
-
-# Given strainrate 
-#@test computeCreepLaw_EpsII(1e-13/s, x1, CreepLawParams())==1e18*2*1e-13Pa       # dimensional input       
-# -------------------------------------------------------------------
-
-
+    # Given strainrate 
+    #@test computeCreepLaw_EpsII(1e-13/s, x1, CreepLawParams())==1e18*2*1e-13Pa       # dimensional input       
+    # -------------------------------------------------------------------
 end


### PR DESCRIPTION
Currently `computeCreepLaw_EpsII()` and `computeCreepLaw_TauII()` take the argument `p::CreepLawVariables`. To use these routines with [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) it's better to have a bit less abstraction. This PR adds a couple of methods `computeCreepLaw_EpsII()` and `computeCreepLaw_TauII()` where the arguments `P,T,f` are `Real` numbers instead of being inside `CreepLawVariables`. The corresponding test file is also fixed.