### PR TITLE
Add functors to viscosity laws

### DIFF
--- a/src/CreepLaw/CreepLaw.jl
+++ b/src/CreepLaw/CreepLaw.jl
@@ -139,7 +139,7 @@ function (η::NTuple{N, PowerlawViscous})(I::Int64, εII) where N
     return η[I](εII)
 end
 
-function (η::AbstractVector{PowerlawViscous})(I::Int64, εII)
+function (η::AbstractVector{PowerlawViscous{T,U1,U2,U3}})(I::Int64, εII) where {T,U1,U2,U3}
     @assert I ≤ length(η)
     return η[I](εII)
 end

--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -54,6 +54,21 @@ DislocationCreep: n=3, r=0.0, A=1.5 MPa^-3 s^-1, E=476.0 kJ mol^-1, V=6.0e-6 m^3
 end
 DislocationCreep(args...) = DislocationCreep(NTuple{length(args[1]), Char}(collect.(args[1])), convert.(GeoUnit,args[2:end-1])..., args[end])
 
+# Compute dislocation creep viscosity
+function (η::DislocationCreep)(EpsII, P::Real, T::Real, f::Real) 
+    return 0.5*EpsII*(1/computeCreepLaw_TauII(EpsII, η, P, T, f))
+end
+
+function (η::NTuple{N, DislocationCreep})(I::Int64, args...) where N 
+    @assert I ≤ N  
+    return η[I](args...)
+end
+
+function (η::AbstractVector{DislocationCreep{T,N,U1,U2,U3,U4,U5}})(I::Int64, args...) where {T,N,U1,U2,U3,U4,U5}
+    @assert I ≤ length(η)
+    return η[I](args...)
+end
+
 function param_info(s::DislocationCreep)
     name = String(collect(s.Name))
     eq = L"\tau_{ij} = 2 \eta  \dot{\varepsilon}_{ij}"
@@ -114,16 +129,15 @@ end
 
 # This computes correction factors to go from experimental data to tensor format
 # A nice discussion 
-function CorrectionFactor(a::DislocationCreep{_T}) where {_T}
-
-    FT = one(_T) 
-    FE = one(_T)
+function CorrectionFactor(a::DislocationCreep)
     if a.Apparatus == AxialCompression
-        FT = sqrt(one(_T)*3)               # relation between differential stress recorded by apparatus and TauII
-        FE = one(_T)*2/sqrt(one(_T)*3)     # relation between gamma recorded by apparatus and EpsII
+        FT = sqrt(3)    # relation between differential stress recorded by apparatus and TauII
+        FE = 2/sqrt(3)  # relation between gamma recorded by apparatus and EpsII
     elseif a.Apparatus == SimpleShear
-        FT = one(_T)*2                     # it is assumed that the flow law parameters were derived as a function of differential stress, not the shear stress. Must be modidified if it is not the case
-        FE = one(_T)*2 
+        # it is assumed that the flow law parameters were derived as a function of differential stress, 
+        # not the shear stress. Must be modidified if it is not the case
+        FT = 2.0 
+        FE = 2.0 
     end
     return FT,FE
 end


### PR DESCRIPTION
I have been doing a bit of more work trying to make the viscosity laws in `GeoParams.jl` compatible with `JustRelax.jl` and `ParallelStencil.jl` . I have come up with a simple solution that should work for single and multiple phases. The idea is just to  add functors to the viscous laws `structs` (e.g. [here](https://github.com/albert-de-montserrat/GeoParams.jl/blob/365a68deedb5bd0fe5188bf460dfdd6e9e2bfa4a/src/CreepLaw/CreepLaw.jl#L73), [here](https://github.com/albert-de-montserrat/GeoParams.jl/blob/365a68deedb5bd0fe5188bf460dfdd6e9e2bfa4a/src/CreepLaw/CreepLaw.jl#L75), and [here](https://github.com/albert-de-montserrat/GeoParams.jl/blob/365a68deedb5bd0fe5188bf460dfdd6e9e2bfa4a/src/CreepLaw/CreepLaw.jl#L80)). This approach should be extensible to density or any other field.

For a single phase the usage  for dislocation creep would be something like this:
```Julia
using GeoParams
using ParallelStencil
using ParallelStencil.FiniteDifferences3D
@init_parallel_stencil(Threads, Float64, 3)

ni = (64,64,64) # grid size
EpsII,T,P,f=rand(ni...),rand(ni...),rand(ni...),rand(ni...)
η = DislocationCreep() # dislocation creep parameters for a single phase

# nodal viscosity
ηdis_i = η(EpsII[1,1,1],T[1,1,1],P[1,1,1],f[1,1,1])

# full viscosity field using broadcasting
ηdis = η.(EpsII,T,P,f)

# parallel stencil kernels
@parallel_indices (i,j,k) function foo!(A, η, EpsII, T, P, f)
    A[i,j,k] = η(EpsII[i,j,k],T[i,j,k],P[i,j,k],f[i,j,k])
    return nothing
end

A = zeros(ni...)
@parallel (1:ni[1],1:ni[1],1:ni[1]) foo!(A, η, EpsII, T, P, f)
```

and for multiple phases:

```Julia
nphase = 5 # number of phases
phase = rand(1:nphase, ni...) # nodal phase

# option (1): ntuple
ηtuple = ntuple(_ -> DislocationCreep(), Val(nphase))
# option (2): vector
ηvect = [DislocationCreep() for _ in 1:nphase]

# nodal viscosity
ηtuple_i = ηtuple[1](EpsII[1,1,1],T[1,1,1],P[1,1,1],f[1,1,1])
ηvect_i = ηvect[1](EpsII[1,1,1],T[1,1,1],P[1,1,1],f[1,1,1])

# full viscosity field using broadcasting
ηdis_tuple = ηtuple[1].(EpsII,T,P,f)
ηdis_vect = ηvect[1].(EpsII,T,P,f)

# parallel stencil kernels
@parallel_indices (i,j,k) function bar!(A, η, phase, T, P, f)
    A[i,j,k] = η(phase[i,j,k], EpsII[i,j,k], T[i,j,k], P[i,j,k], f[i,j,k])
    # A[i,j,k] = η[phase[i,j,k]](EpsII[i,j,k], T[i,j,k], P[i,j,k], f[i,j,k]) # alternative syntax
    return nothing
end

@parallel (1:ni[1],1:ni[1],1:ni[1]) bar!(A, ηtuple, phase, T, P, f)
@parallel (1:ni[1],1:ni[1],1:ni[1]) bar!(A, ηvect, phase, T, P, f)
```

And then for practical reasons one could dump the grid viscosity field and all the different laws in a single `struct` :
```Julia
struct Viscosity{T1,T2}
    val::T1
    params::T2
end

# parallel stencil kernels
@parallel_indices (i,j,k) function bar2!(visc, phase, T, P, f)
    visc.val[i,j,k] = visc.params(phase[i,j,k], EpsII[i,j,k], T[i,j,k], P[i,j,k], f[i,j,k])
    return nothing
end

visc = Viscosity(rand(ni...), ηvect)
@parallel (1:ni[1],1:ni[1],1:ni[1]) bar2!(visc, phase, T, P, f)
```

This has been implemented for `LinearViscous`, `PowerlawViscous`, and `DislocationCreep`. @boriskaus is there any modification/additional feature that would be useful for your cases?

## Performance

I have also done some performance tests and while in CPUs there is not much difference between a `NTuple` or a `Vector`  of phases (apart from a fairly higher compile time for the first) ,  `Vector` performs much better with CUDA (and for some reason CUDA crashes with tuples of length between 40 and 80):

### Dislocation creep CPU
[perf_cpu_dislocation.pdf](https://github.com/JuliaGeodynamics/GeoParams.jl/files/8333976/perf_cpu_dislocation.pdf)

### Dislocation creep CUDA
[perf_cuda_dislocation.pdf](https://github.com/JuliaGeodynamics/GeoParams.jl/files/8333980/perf_cuda_dislocation.pdf)

### Power law creep CPU
[perf_cpu_powerlaw.pdf](https://github.com/JuliaGeodynamics/GeoParams.jl/files/8333983/perf_cpu_powerlaw.pdf)

### Power law creep CUDA
[perf_cuda_powerlaw.pdf](https://github.com/JuliaGeodynamics/GeoParams.jl/files/8333984/perf_cuda_powerlaw.pdf)

