### PR TITLE
Fastpow

### DIFF
--- a/src/CreepLaw/DiffusionCreep.jl
+++ b/src/CreepLaw/DiffusionCreep.jl
@@ -51,9 +51,9 @@ function computeCreepLaw_EpsII(TauII, a::DiffusionCreep, c::CreepLawVariables)
     @unpack_val n,r,p,A,E,V,R = a
     @unpack_val P,T,f,d       = c
     
-    FT, FE = CorrectionFactor(a);    
+    FT, FE = CorrectionFactor(a)
    
-    return A*(TauII*FT)^n*f^r*d^p*exp(-(E + P*V)/(R*T))/FE; 
+    return A*fastpow(TauII*FT,n)*fastpow(f,r)*fastpow(d,p)*exp(-(E + P*V)/(R*T))/FE
 end
 
 # EpsII .= A.*(TauII.*FT).^n.*f.^r.*d.^p.*exp.(-(E.+P.*V)./(R.*T))./FE; Once we have a 
@@ -62,9 +62,9 @@ function computeCreepLaw_TauII(EpsII, a::DiffusionCreep, c::CreepLawVariables)
     @unpack_val n,r,A,E,V,R = a
     @unpack_val P,T,f,d     = c
 
-    FT, FE = CorrectionFactor(a);    
+    FT, FE = CorrectionFactor(a)  
 
-    return A^(-1/n)*(EpsII*FE)^(1/n)*f^(-r/n)*d^(-p/n)*exp((E + P*V)/(n * R*T))/FT;
+    return fastpow(A,-1/n)*fastpow(EpsII*FE,1/n)*fastpow(f, -r/n)*fastpow(d,-p/n)*exp((E + P*V)/(n * R*T))/FT
 end
 
 # Print info 

--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -12,11 +12,10 @@ import GeoParams.param_info
 
 export  DislocationCreep,
         SetDislocationCreep,
-        DislocationCreep_info
+        dεII_dτII,
+        dτII_dεII
 
 const AxialCompression, SimpleShear, Invariant = 1,2,3
-
-
 
 
 # Dislocation Creep ------------------------------------------------
@@ -48,7 +47,7 @@ DislocationCreep: n=3, r=0.0, A=1.5 MPa^-3 s^-1, E=476.0 kJ mol^-1, V=6.0e-6 m^3
     E::GeoUnit{T,U3}        = 476.0kJ/mol        # activation energy
     V::GeoUnit{T,U4}        = 6e-6m^3/mol        # activation volume
     R::GeoUnit{T,U5}        = 8.314J/mol/K       # Universal gas constant
-    Apparatus::Int32        = AxialCompression   # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
+    Apparatus::Int64        = 1   # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 end
 DislocationCreep(args...) = DislocationCreep(NTuple{length(args[1]), Char}(collect.(args[1])), convert.(GeoUnit,args[2:end-1])..., args[end])
 
@@ -64,43 +63,37 @@ end
 
 # Calculation routines for linear viscous rheologies
 # All inputs must be non-dimensionalized (or converted to consitent units) GeoUnits
-function computeCreepLaw_EpsII(TauII, a::DislocationCreep, p::CreepLawVariables)
+
+@inline function computeCreepLaw_EpsII(TauII, a::DislocationCreep; P::_R, T::_R, f::_R, args...) where _R<:Real
     @unpack_val n,r,A,E,V,R = a
-    @unpack_val P,T,f       = p
     
     FT, FE = CorrectionFactor(a)
-   
-    return A*fastpow(TauII*FT,n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE
+
+    return A*fastpow(TauII*FT,n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE   
 end
 
-function computeCreepLaw_EpsII(TauII, a::DislocationCreep, P::_R, T::_R, f::_R) where _R<:Real
+@inline function dεII_dτII(TauII, a::DislocationCreep; P, T, f, kwargs...)
     @unpack_val n,r,A,E,V,R = a
-    
-    FT, FE = CorrectionFactor(a);    
-   
-    return A*fastpow(TauII*FT, n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE; 
+
+    FT, FE = CorrectionFactor(a)
+    return fastpow(FT*TauII,-1+n)*fastpow(f,r)*A*FT*n*exp((-E-P*V)/(R*T))*(1/FE)
 end
 
 # EpsII .= A.*(TauII.*FT).^n.*f.^r.*exp.(-(E.+P.*V)./(R.*T))./FE; Once we have a 
 # All inputs must be non-dimensionalized (or converted to consistent units) GeoUnits
-function computeCreepLaw_TauII(EpsII, a::DislocationCreep, p::CreepLawVariables)
+@inline function computeCreepLaw_TauII(EpsII, a::DislocationCreep; P::_R, T::_R, f::_R, args...) where _R<:Real
     @unpack_val n,r,A,E,V,R = a
-    @unpack_val P,T,f       = p
 
-    FT, FE = CorrectionFactor(a)    
+    FT, FE = CorrectionFactor(a)
 
-    return fastpow(A, -1/n)*fastpow(EpsII*FE,1/n)*fastpow(f, -r/n)*exp((E + P*V)/(n * R*T))/FT;
+    return A*fastpow(TauII*FT, n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE
 end
 
-
-# EpsII .= A.*(TauII.*FT).^n.*f.^r.*exp.(-(E.+P.*V)./(R.*T))./FE; Once we have a 
-# All inputs must be non-dimensionalized (or converted to consistent units) GeoUnits
-function computeCreepLaw_TauII(EpsII, a::DislocationCreep, P::_R, T::_R, f::_R) where _R<:Real
+@inline function dτII_dεII(EpsII, a::DislocationCreep; P, T, f, kwargs...)
     @unpack_val n,r,A,E,V,R = a
 
-    FT, FE = CorrectionFactor(a);    
-
-    return fastpow(A,-1/n)*fastpow(EpsII*FE,1/n)*fastpow(f,-r/n)*exp((E + P*V)/(n * R*T))/FT
+    FT, FE = CorrectionFactor(a)
+    return fastpow(FT*EpsII, -1+1/n)*fastpow(f,-r/n)*fastpow(A,-1/n)*FE*n*exp((E+P*V)/(n*R*T))*(1/(FT*n))
 end
 
 
@@ -113,15 +106,11 @@ end
 # This computes correction factors to go from experimental data to tensor format
 # A nice discussion 
 function CorrectionFactor(a::DislocationCreep{_T}) where {_T}
-
-    FT = one(_T) 
-    FE = one(_T)
     if a.Apparatus == AxialCompression
-        FT = sqrt(one(_T)*3)               # relation between differential stress recorded by apparatus and TauII
-        FE = one(_T)*2/sqrt(one(_T)*3)     # relation between gamma recorded by apparatus and EpsII
+        FT = sqrt(one(_T)*3) # relation between differential stress recorded by apparatus and TauII
+        FE = 2/FT            # relation between gamma recorded by apparatus and EpsII
     elseif a.Apparatus == SimpleShear
-        FT = one(_T)*2                     # it is assumed that the flow law parameters were derived as a function of differential stress, not the shear stress. Must be modidified if it is not the case
-        FE = one(_T)*2 
+        FT = FE = one(_T)*2  # it is assumed that the flow law parameters were derived as a function of differential stress, not the shear stress. Must be modidified if it is not the case
     end
     return FT,FE
 end

--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -70,7 +70,7 @@ function computeCreepLaw_EpsII(TauII, a::DislocationCreep, p::CreepLawVariables)
     
     FT, FE = CorrectionFactor(a)
    
-    return A*(TauII*FT)^n*f^r*exp(-(E + P*V)/(R*T))/FE
+    return A*fastpow(TauII*FT,n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE
 end
 
 function computeCreepLaw_EpsII(TauII, a::DislocationCreep, P::_R, T::_R, f::_R) where _R<:Real
@@ -78,7 +78,7 @@ function computeCreepLaw_EpsII(TauII, a::DislocationCreep, P::_R, T::_R, f::_R) 
     
     FT, FE = CorrectionFactor(a);    
    
-    return A*(TauII*FT)^n*f^r*exp(-(E + P*V)/(R*T))/FE; 
+    return A*fastpow(TauII*FT, n)*fastpow(f,r)*exp(-(E + P*V)/(R*T))/FE; 
 end
 
 # EpsII .= A.*(TauII.*FT).^n.*f.^r.*exp.(-(E.+P.*V)./(R.*T))./FE; Once we have a 
@@ -89,7 +89,7 @@ function computeCreepLaw_TauII(EpsII, a::DislocationCreep, p::CreepLawVariables)
 
     FT, FE = CorrectionFactor(a)    
 
-    return A^(-1/n)*(EpsII*FE)^(1/n)*f^(-r/n)*exp((E + P*V)/(n * R*T))/FT;
+    return fastpow(A, -1/n)*fastpow(EpsII*FE,1/n)*fastpow(f, -r/n)*exp((E + P*V)/(n * R*T))/FT;
 end
 
 
@@ -100,7 +100,7 @@ function computeCreepLaw_TauII(EpsII, a::DislocationCreep, P::_R, T::_R, f::_R) 
 
     FT, FE = CorrectionFactor(a);    
 
-    return A^(-1/n)*(EpsII*FE)^(1/n)*f^(-r/n)*exp((E + P*V)/(n * R*T))/FT
+    return fastpow(A,-1/n)*fastpow(EpsII*FE,1/n)*fastpow(f,-r/n)*exp((E + P*V)/(n * R*T))/FT
 end
 
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,7 +1,5 @@
 # Various helper functions (mosty for internal use)
 
-
-
 # Finds index in an allocation-free manner
 function find_ind(x::NTuple{N,_I}, k::_I) where {N, _I<:Integer}
     @inbounds for i in 1:N
@@ -11,8 +9,6 @@ function find_ind(x::NTuple{N,_I}, k::_I) where {N, _I<:Integer}
     end
     return 0
 end
-
-
 
 # Find max element in a tuple
 function find_max_tuple(t::NTuple{N,T}) where {N,T}
@@ -36,3 +32,11 @@ function ntuple_idx(args::NamedTuple, I::Integer...)
     v = getindex.(values(args), Tuple(I)...)
     return (; zip(k, v)...)
 end
+
+# fast exponential (in exchange of some accuracy)
+function fastpow(x::Number, n::Integer)
+    n > 3 && return exp(log(x)*n)
+    return x^n
+end
+
+fastpow(x::Number, n::AbstractFloat) =  exp(log(x)*n)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -33,7 +33,7 @@ function ntuple_idx(args::NamedTuple, I::Integer...)
     return (; zip(k, v)...)
 end
 
-# fast exponential (in exchange of some accuracy)
+# fast exponential
 function fastpow(x::Number, n::Integer)
     n > 3 && return exp(log(x)*n)
     return x^n

--- a/test/test_CreepLaw.jl
+++ b/test/test_CreepLaw.jl
@@ -3,12 +3,12 @@ using GeoParams
 
 @testset "CreepLaw" begin
 
- #Make sure structs are isbits
- x = LinearViscous()
- @test isbits(x)
+#Make sure structs are isbits
+x = LinearViscous()
+@test isbits(x)
  
- x = PowerlawViscous()
- @test isbits(x)
+x = PowerlawViscous()
+@test isbits(x)
 
 # This tests the MaterialParameters structure
 CharUnits_GEO   =   GEO_units(viscosity=1e19, length=1000km);
@@ -29,14 +29,16 @@ x1_ND = nondimensionalize(x1_ND,CharUnits_GEO)
 # perform a computation with the viscous creep laws 
 
 # Given stress
-@test computeCreepLaw_EpsII(1e6Pa, x1, CreepLawVariables())==5e-13/s                # dimensional input       
-@test computeCreepLaw_EpsII(1e0, x1_ND, CreepLawVariables())==5.0                   # non-dimensional
-@test computeCreepLaw_EpsII([1e0; 2.0], x1_ND, CreepLawVariables())==[5.0; 10.0]    # vector input
+vars = CreepLawVariables() 
+args = (P=vars.P, T=vars.T, f=vars.f, d=vars.d)
+@test computeCreepLaw_EpsII(1e6Pa, x1, args) ==5e-13/s                # dimensional input       
+@test computeCreepLaw_EpsII(1e0, x1_ND, args)==5.0                   # non-dimensional
+@test computeCreepLaw_EpsII([1e0; 2.0], x1_ND, args)==[5.0; 10.0]    # vector input
 
 # Given strainrate 
-@test computeCreepLaw_TauII(1e-13/s, x1, CreepLawVariables())==1e18*2*1e-13Pa       # dimensional input       
-@test computeCreepLaw_TauII(1e0, x1_ND, CreepLawVariables())==0.2                   # non-dimensional
-@test computeCreepLaw_TauII([1e0; 2.0], x1_ND, CreepLawVariables())==[0.2; 0.4]     # vector input
+@test computeCreepLaw_TauII(1e-13/s, x1, args)==1e18*2*1e-13Pa       # dimensional input       
+@test computeCreepLaw_TauII(1e0, x1_ND, args)==0.2                   # non-dimensional
+@test computeCreepLaw_TauII([1e0; 2.0], x1_ND, args)==[0.2; 0.4]     # vector input
 # -------------------------------------------------------------------
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
While profiling the viscosity computations I saw that ~75% of the time of the whole local iterations routine was spend in doing the powers with floating point exponents of the rheology laws.  I added the faster  power:
```julia
# fast exponential
function fastpow(x::Number, n::Integer)
    n > 3 && return exp(log(x)*n)
    return x^n
end

fastpow(x::Number, n::AbstractFloat) =  exp(log(x)*n)
```
I obsserved a  ~75% speed up in the local iterations  calculation using this approach. By computing the powers like this there's a slight trade-off in accuracy, but I would say its acceptable:
```julia
julia> @btime normal_power()
  318.598 ns (0 allocations: 0 bytes)
# 4 iteratios and residual = 5.892568764240876e-10

julia> @btime fast_power()
  182.568 ns (0 allocations: 0 bytes)
# 4 iteratios and  residual 5.89256100096274e-10
```