### PR TITLE
Seismic S-wave velocity correction for (shallow depth) porosity

### DIFF
--- a/docs/src/man/seismicvelocity.md
+++ b/docs/src/man/seismicvelocity.md
@@ -26,6 +26,19 @@ To compute melt-content based correction for seismic waves velocities, you can u
 ```@docs
 GeoParams.melt_correction
 ```
+
+# Seismic S-wave velocity correction for (shallow depth) porosity
+
+# Methods
+Ths routine is based on the equilibrium geometry model for the solid skeleton of Takei et al. (1998) and the porosity-depth empirical relationship of Chen et al. (2020)
+
+# Computational routines
+To compute porosity based correction for seismic S-wave velocity, you can use:
+```@docs
+GeoParams.porosity_correction
+```
+
+
 # Seismic velocity correction for anelasticity
 
 # Methods

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -190,7 +190,8 @@ export compute_pwave_velocity,
     compute_wave_velocity!,
     ConstantSeismicVelocity,
     anelastic_correction,
-    melt_correction
+    melt_correction,
+    porosity_correction
 
 # Add melting parameterizations
 include("./MeltFraction/MeltingParameterization.jl")

--- a/test/test_SeismicVelocity.jl
+++ b/test/test_SeismicVelocity.jl
@@ -69,6 +69,12 @@ using GeoParams
     )
     @test [Vp_cor, Vs_cor] ≈ [7.336238790906285, 4.314027804335563]
 
+    Vs_cor = porosity_correction(
+         94.5, 61.0, 1000.0, 3198.0, 4.36, 0.25, 0.25
+    )
+    @test [Vs_cor] ≈ [2.226167083352012]
+
+
     Vs_anel = anelastic_correction(0, 4.36734, 5.0, 1250.0)
     @test Vs_anel ≈ 4.1182815519599325
 end


### PR DESCRIPTION
 Ths routine is based on the equilibrium geometry model for the solid skeleton of Takei et al. (1998) and the porosity-depth empirical relationship of Chen et al. (2020)