### PR TITLE
Method to compute gravity given material phases

### DIFF
--- a/src/Computations.jl
+++ b/src/Computations.jl
@@ -26,10 +26,8 @@ end
     fn::F, MatParam::NTuple{N,AbstractMaterialParamsStruct}, Phase::Int64, args
 ) where {F,N}
     quote
-        T = isempty(args) ? 0.0 : zero(typeof(args).types[1])
-        out = T
         Base.Cartesian.@nexprs $N i ->
-            out += MatParam[i].Phase == Phase ? fn(MatParam[i], args) : T
+            @inbounds (MatParam[i].Phase == Phase) && return fn(MatParam[i], args)
     end
 end
 

--- a/src/GravitationalAcceleration/GravitationalAcceleration.jl
+++ b/src/GravitationalAcceleration/GravitationalAcceleration.jl
@@ -40,9 +40,8 @@ function compute_gravity(s::ConstantGravity{_T}) where {_T}
 end
 
 # Calculation routine
-@generated function compute_gravity( MatParam::NTuple{N,AbstractMaterialParamsStruct}, Phase::Integer) where {N}
+@inline @generated function compute_gravity( MatParam::NTuple{N,AbstractMaterialParamsStruct}, Phase::Integer) where {N}
     quote
-        Base.@_inline_meta
         Base.Cartesian.@nexprs $N i ->
             (MatParam[i].Phase == Phase) && return compute_gravity(MatParam[i].Gravity[1])
     end

--- a/src/GravitationalAcceleration/GravitationalAcceleration.jl
+++ b/src/GravitationalAcceleration/GravitationalAcceleration.jl
@@ -4,7 +4,7 @@ module GravitationalAcceleration
 
 using Parameters, LaTeXStrings, Unitful
 using ..Units
-using GeoParams: AbstractMaterialParam
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
 import Base.show, GeoParams.param_info
 using ..MaterialParameters: MaterialParamsInfo
 
@@ -37,6 +37,15 @@ function compute_gravity(s::ConstantGravity{_T}) where {_T}
     @unpack_val g = s
 
     return g
+end
+
+# Calculation routine
+@generated function compute_gravity( MatParam::NTuple{N,AbstractMaterialParamsStruct}, Phase::Integer) where {N}
+    quote
+        Base.@_inline_meta
+        Base.Cartesian.@nexprs $N i ->
+            (MatParam[i].Phase == Phase) && return compute_gravity(MatParam[i].Gravity[1])
+    end
 end
 
 # Print info 


### PR DESCRIPTION
This fixes the problem where a call like this `compute_gravity(MatParam[Phases[i,j]].Gravity[1])` is type-unstable. The new type-stable method can now be called as  `compute_gravity(MatParam, Phases[i,j])`.