### PR TITLE
type instability

### DIFF
--- a/src/Computations.jl
+++ b/src/Computations.jl
@@ -28,6 +28,7 @@ end
     quote
         Base.Cartesian.@nexprs $N i ->
             @inbounds (MatParam[i].Phase == Phase) && return fn(MatParam[i], args)
+        return 0.0
     end
 end
 


### PR DESCRIPTION
Fix type instability in [here](https://github.com/JuliaGeodynamics/GeoParams.jl/blob/a81bf559b8ed6e9f42920210af3bb6c2cfbd6689/src/Computations.jl#L25) which led to a 40% performance drop.