### PR TITLE
Remove println() calls when CUDA is active

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.18"
 
 [deps]
 BibTeX = "7b0aa2c9-049f-5cec-894a-2b6b781bb25e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -24,6 +25,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BibTeX = "0.1"
+ForwardDiff = "0.10"
 Interpolations = "0.13, 0.14"
 KernelDensitySJ = "0.2"
 LaTeXStrings = "1.2"
@@ -37,7 +39,6 @@ StatsBase = "0.1 - 0.32, 0.33"
 UnPack = "1.0"
 Unidecode = "1.0"
 Unitful = "1.0"
-ForwardDiff = "0.10"
 julia = "1.7"
 
 [extras]

--- a/src/CompositeRheologies.jl
+++ b/src/CompositeRheologies.jl
@@ -1,6 +1,7 @@
 # This holds structures and computational routines for compositional rheologies
 using StaticArrays
 using Setfield
+using Requires
 
 export CompositeRheology, Parallel, create_rheology_string, print_rheology_matrix
 export time_τII_0D, compute_εII_harmonic, compute_τII_AD
@@ -8,6 +9,8 @@ export computeViscosity_εII, computeViscosity_εII_AD
 import Base.getindex
 
 import GeoParams.Units: nondimensionalize, dimensionalize
+
+@inline isCUDA() =  isdefined(@__MODULE__,:CUDA) 
 
 """
     Put rheological elements in parallel 
@@ -305,7 +308,7 @@ Performs local iterations versus stress for a given total strain rate for a give
     # Initial guess
     τII = compute_τII_harmonic(v, εII, args)
     
-    verbose && println("initial τII = $τII")
+    !isCUDA() && verbose && println("initial stress_II = $τII")
 
     # Local Iterations
     iter = 0
@@ -325,9 +328,9 @@ Performs local iterations versus stress for a given total strain rate for a give
         ϵ = abs(τII - τII_prev) * inv(abs(τII))
         τII_prev = τII
 
-        verbose && println(" iter $(iter) $ϵ")
+        !isCUDA() && verbose && println(" iter $(iter) $ϵ")
     end
-    if verbose
+    if !isCUDA() && verbose
         println("final τII = $τII")
         println("---")
     end
@@ -350,7 +353,7 @@ Performs local iterations versus stress for a given strain rate using AD
     # Initial guess
     τII = compute_τII_harmonic(v, εII, args)
     
-    verbose && println("initial τII = $τII")
+    !isCUDA() && verbose && println("initial τII = $τII")
 
     # Local Iterations
     iter = 0
@@ -370,9 +373,9 @@ Performs local iterations versus stress for a given strain rate using AD
         ϵ = abs(τII - τII_prev) * inv(abs(τII))
         τII_prev = τII
 
-        verbose && println(" iter $(iter) $ϵ")
+        !isCUDA() && verbose && println(" iter $(iter) $ϵ")
     end
-    if verbose
+    if !isCUDA() && verbose
         println("final τII = $τII")
         println("---")
     end
@@ -386,7 +389,7 @@ end
     # Initial guess
     εII = compute_εII_harmonic(v, τII, args)
 
-    verbose && println("initial εII = $εII")
+    !isCUDA() && verbose && println("initial εII = $εII")
 
     # Local Iterations
     iter = 0
@@ -405,10 +408,10 @@ end
 
         ϵ = abs(εII - εII_prev) * inv(εII)
         εII_prev = εII
-        verbose && println(" iter $(iter) $ϵ")
+        !isCUDA() && verbose && println(" iter $(iter) $ϵ")
         
     end
-    if verbose
+    if !isCUDA() && verbose
         println("final εII = $εII")
         println("---")
     end
@@ -444,11 +447,11 @@ Performs local iterations versus strain rate for a given stress
 
         ϵ = abs(εII - εII_prev) / abs(εII)
         εII_prev = εII
-        if verbose
+        if !isCUDA() && verbose
             println(" iter $(iter) $ϵ")
         end
     end
-    if verbose
+    if !isCUDA() && verbose
         println("---")
     end
 
@@ -479,7 +482,7 @@ This performs nonlinear Newton iterations for `τII` with given `εII_total` for
         τ_initial = compute_τII_harmonic(c, εII_total, args)
     end
 
-    verbose && println("τII guess = $τ_initial")
+    !isCUDA() && verbose && println("τII guess = $τ_initial")
 
     x    = @MVector ones(_T, n)
     x   .= εII_total
@@ -519,9 +522,9 @@ This performs nonlinear Newton iterations for `τII` with given `εII_total` for
         x .+= dx   
 
         ϵ    = sum(abs.(dx)./(abs.(x)))
-        verbose && println(" iter $(iter) $ϵ")
+        !isCUDA() && verbose && println(" iter $(iter) $ϵ")
     end
-    verbose && println("---")
+    !isCUDA() && verbose && println("---")
     
     if (iter == max_iter)
         error("iterations did not converge")

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -279,6 +279,11 @@ function __init__()
         print("Adding plotting routines of GeoParams through GLMakie")
         @eval include("./Plotting.jl")
     end
+
+    @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" begin
+        print("Adding CUDA")
+        Base.eval(MaterialParameters.ConstitutiveRelationships, Meta.parse("using CUDA"))
+    end
 end
 
 #Set functions aliases using @use


### PR DESCRIPTION
`println()` does not work in CUDA kerneles. This PR conditionally loads CUDA with `Requires` and switches off all the calls to `println` when CUDA has been loaded. 