### PR TITLE
nondimensionalize tuples

### DIFF
--- a/src/Units.jl
+++ b/src/Units.jl
@@ -588,7 +588,12 @@ nondimensionalize(param::AbstractArray{<:Number}, g::GeoUnits{TYPE}) where {TYPE
 
 nondimensionalizes a tuple of parameters    
 """
-nondimensionalize(param::NTuple{N,Union{Quantity,GeoUnit}}, g::GeoUnits{TYPE}) where {N,TYPE}  = Tuple(nondimensionalize.(param,fill(g,2)))
+function nondimensionalize(param::NTuple{N,Union{Quantity,GeoUnit}}, g::GeoUnits{TYPE}) where {N,TYPE}
+    ntuple(Val(N)) do i
+        Base.@_inline_meta
+        nondimensionalize(param[i], g)
+    end
+end
 
 
 # This computes the characteristic value

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -583,6 +583,14 @@ end
 # If it is an array, but has no units we cannot know how to nondimensionalize it
 nondimensionalize(param::AbstractArray{<:Number}, g::GeoUnits{TYPE}) where {TYPE} = param
 
+"""
+    param = nondimensionalize(param::NTuple{N,Quantity}, g::GeoUnits{TYPE})
+
+nondimensionalizes a tuple of parameters    
+"""
+nondimensionalize(param::NTuple{N,Union{Quantity,GeoUnit}}, g::GeoUnits{TYPE}) where {N,TYPE}  = Tuple(nondimensionalize.(param,fill(g,2)))
+
+
 # This computes the characteristic value
 function compute_units(
     param::GeoUnit{<:Union{T,AbstractArray{T}},U}, g::GeoUnits{TYPE}

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -394,4 +394,14 @@ using GeoParams
     @btime f!($r, $rho9_ND, $c) 
     =#
 
+    # test arrays of parameters 
+    param = (100km, 800/s)
+    param1 = (GeoUnit(100km), GeoUnit(800/s))
+    g=GEO_units();
+
+    p_nd = nondimensionalize(param, g)
+    @test p_nd == (0.1, 8.0e15)
+
+    p1_nd = nondimensionalize(param1, g)
+    
 end


### PR DESCRIPTION
Very simple PR that allows nondimensionalising Tuples of dimensional parameters, to shorten user codes:
```Julia
julia> g=GEO_units();
julia> a,b = nondimensionalize((100km, 800/s),g)
(100 km, 800 s⁻¹·⁰)
```

