### PR TITLE
Extract elastic parameters from MaterialParams

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -61,8 +61,10 @@ export param_info,
     CompositeRheology,
     AbstractComposite,
     AbstractConstitutiveLaw
-    AxialCompression, SimpleShear, Invariant ,
-    
+    AxialCompression, SimpleShear, Invariant,
+    get_G, 
+    get_Kb
+
 # add methods programatically 
 for myType in (:LinearViscous, :DiffusionCreep, :DislocationCreep, :ConstantElasticity, :DruckerPrager, :ArrheniusType)
     @eval begin

--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -20,7 +20,9 @@ export compute_εII,            # calculation routines
     SetConstantElasticity,  # helper function
     AbstractElasticity,
     isvolumetric, 
-    effective_εII, effective_ε
+    effective_εII, effective_ε,
+    get_G, 
+    get_Kb
 
 # ConstantElasticity  -------------------------------------------------------
 
@@ -83,6 +85,15 @@ end
 function isvolumetric(a::ConstantElasticity)
     @unpack_val ν = a
     return ν == 0.5 ? false : true
+end
+
+for modulus in (:G, :Kb)
+    fun = Symbol("get_$(string(modulus))")
+    @eval begin
+        @inline $(fun)(a::ConstantElasticity) = a.$(modulus).val
+        @inline $(fun)(a::AbstractMaterialParamsStruct) = $(fun)(a.Elasticity[1])
+        @inline $(fun)(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
+    end
 end
 
 # Calculation routines

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -133,6 +133,9 @@ export compute_density,                                # computational routines
 using .MaterialParameters.ConstitutiveRelationships
 export AxialCompression, SimpleShear, Invariant 
 
+const get_shearmodulus = get_G
+const get_bulkmodulus = get_Kb
+
 #       Calculation routines
 export dεII_dτII,
     dτII_dεII,
@@ -171,6 +174,10 @@ export dεII_dτII,
     ConstantElasticity,
     SetConstantElasticity,
     effective_εII,
+    get_G, 
+    get_Kb,
+    get_shearmodulus, 
+    get_bulkmodulus, 
 
     #       Plasticity
     AbstractPlasticity,

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -27,20 +27,20 @@ using GeoParams
 
     @test isvolumetric(a) == true
 
-    a = ConstantElasticity()
+    b = ConstantElasticity()
     v = SetMaterialParams(; Elasticity = ConstantElasticity())
     vv=(
         SetMaterialParams(; Phase=1, Elasticity = ConstantElasticity()),
         SetMaterialParams(; Phase=2, Elasticity = ConstantElasticity()),
     )
 
-    @test get_G(a) == a.G.val
-    @test get_G(v) == a.G.val
-    @test get_G(vv, 1) == get_G(vv, 2) == a.G.val # for multiple phases
+    @test get_G(b) == b.G.val
+    @test get_G(v) == b.G.val
+    @test get_G(vv, 1) == get_G(vv, 2) == b.G.val # for multiple phases
 
-    @test get_Kb(a) == a.Kb.val
-    @test get_Kb(v) == a.Kb.val
-    @test get_Kb(vv, 1) == get_Kb(vv, 2) == a.Kb.val # for multiple phases
+    @test get_Kb(b) == b.Kb.val
+    @test get_Kb(v) == b.Kb.val
+    @test get_Kb(vv, 1) == get_Kb(vv, 2) == b.Kb.val # for multiple phases
 
     # Compute with Floats
     τII = 20e6

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -27,6 +27,20 @@ using GeoParams
 
     @test isvolumetric(a) == true
 
+    v = SetMaterialParams(; Elasticity = ConstantElasticity())
+    vv=(
+        SetMaterialParams(; Phase=1, Elasticity = ConstantElasticity()),
+        SetMaterialParams(; Phase=2, Elasticity = ConstantElasticity()),
+    )
+
+    @test get_G(a) == a.G.val
+    @test get_G(v) == a.G.val
+    @test get_G(vv, 1) == get_G(vv, 2) == a.G.val # for multiple phases
+
+    @test get_Kb(a) == a.Kb.val
+    @test get_Kb(v) == a.Kb.val
+    @test get_Kb(vv, 1) == get_Kb(vv, 2) == a.Kb.val # for multiple phases
+
     # Compute with Floats
     τII = 20e6
     τII_old = 15e6

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -27,6 +27,7 @@ using GeoParams
 
     @test isvolumetric(a) == true
 
+    a = ConstantElasticity()
     v = SetMaterialParams(; Elasticity = ConstantElasticity())
     vv=(
         SetMaterialParams(; Phase=1, Elasticity = ConstantElasticity()),


### PR DESCRIPTION
Convinience methods to extract the shear and bulk modulus from `ConstantElasticity`

```julia
    a = ConstantElasticity()
    v = SetMaterialParams(; Elasticity = ConstantElasticity())
    vv=(
        SetMaterialParams(; Phase=1, Elasticity = ConstantElasticity()),
        SetMaterialParams(; Phase=2, Elasticity = ConstantElasticity()),
    )

    get_G(a) == a.G.val
    get_G(v) == a.G.val
    get_G(vv, 1) == get_G(vv, 2) == a.G.val # for multiple phases
    get_Kb(a) == a.Kb.val
    get_Kb(v) == a.Kb.val
    get_Kb(vv, 1) == get_Kb(vv, 2) == a.Kb.val # for multiple phases
```