### PR TITLE
Local density function for multi-phases rheology given volume fractions

### DIFF
--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -18,6 +18,7 @@ abstract type AbstractDensity{T} <: AbstractMaterialParam end
 
 export compute_density,        # calculation routines
     compute_density!,       # in place calculation
+    compute_density_ratio, 
     param_info,             # info about the parameters
     AbstractDensity,
     ConstantDensity,        # constant
@@ -274,5 +275,6 @@ This assumes that the `PhaseRatio` of every point is specified as an Integer in 
 """
 compute_density!(args::Vararg{Any, N}) where N = compute_param!(compute_density, args...) #Multiple dispatch to rest of routines found in Computations.jl
 compute_density(args::Vararg{Any, N}) where N = compute_param(compute_density, args...)
+compute_density_ratio(args::Vararg{Any, N}) where N = compute_param_times_frac(compute_density, args...)
 
 end

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -115,6 +115,7 @@ export PhaseDiagram_LookupTable, PerpleX_LaMEM_Diagram
 using .MaterialParameters.Density
 export compute_density,                                # computational routines
     compute_density!,
+    compute_density_ratio,
     param_info,
     AbstractDensity,
     No_Density,

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -231,4 +231,25 @@ using GeoParams
     #Test computation of density given a single phase and P,T as scalars
     Phase, P, T = 0, 1.0, 1.0
     @test compute_density(Mat_tup1, Phase, (P=P[1], T=T[1])) == 2900.0
+
+    # Local phase ratio density calculation
+    args = (P=0.0, T=20.0)
+    rheologies = (
+        SetMaterialParams(;
+            Name="Crust",
+            Phase=0,
+            CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e23Pas)),
+            Density=ConstantDensity(; ρ=2900kg / m^3),
+        ),
+        SetMaterialParams(;
+            Name="Lower Crust",
+            Phase=1,
+            CreepLaws=(PowerlawViscous(; n=5.0), LinearViscous(; η=1e21Pas)),
+            Density=Compressible_Density(; ρ0=3000kg / m^3),
+        )
+    )
+
+    PhaseRatio = (0.5, 0.5)
+    @test 2950e0 == compute_density_ratio(PhaseRatio, rheologies, args)
+
 end


### PR DESCRIPTION
There was an in-place function `compute_density!(rho, Mat_tup1, PhaseRatio, args)` to do this but we are missing the one to do it locally, which is more convinient for our codes. To avoid name redunancy and ambiguity, I think it is better to use a different name for local volume fractions kernels, e.g. `compute_density_ratio(PhaseRatio, rheologies, args)` here.
