### PR TITLE
compute_param_times_frac compat with CellArrays

### DIFF
--- a/src/Computations.jl
+++ b/src/Computations.jl
@@ -111,7 +111,7 @@ end
 
 #Multiplies parameter with the fraction of a phase
 @generated function compute_param_times_frac(
-    fn::F, PhaseRatios::NTuple{N,T}, MatParam::NTuple{N,AbstractMaterialParamsStruct}, argsi
+    fn::F, PhaseRatios::Union{NTuple{N,T}, SVector{N,T}}, MatParam::NTuple{N,AbstractMaterialParamsStruct}, argsi
 ) where {F,N,T}
     # # Unrolled dot product
     quote


### PR DESCRIPTION
Make `compute_param_times_frac` compatible with `StaticArrays` so that it works with `CellArrays.jl`