### PR TITLE
Local compute_param methods for phase ratios

### DIFF
--- a/src/Viscosity/Viscosity.jl
+++ b/src/Viscosity/Viscosity.jl
@@ -65,7 +65,7 @@ end
     quote
         Base.@_inline_meta
         η = 0.0
-        Base.@nexprs $N i -> η += inv(fn(v[i], II, args)) * !iselastic(v[i]) * !isplastic(v[i])
+        Base.@nexprs $N i -> !isplastic(v[i]) && (η += inv(fn(v[i], II, args)) * !iselastic(v[i]))
         return inv(η)
     end
 end
@@ -138,7 +138,7 @@ end
     quote
         Base.@_inline_meta
         η = 0.0
-        Base.@nexprs $N i -> η += inv(fn(v[i], II, args)) * !isplastic(v[i])
+        Base.@nexprs $N i -> !isplastic(v[i]) && (η += inv(fn(v[i], II, args)))
         return η
     end
 end

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -1,5 +1,4 @@
-using Test
-using GeoParams
+using Test, GeoParams, StaticArrays
 
 @testset "Density.jl" begin
 

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -251,5 +251,10 @@ using GeoParams
 
     PhaseRatio = (0.5, 0.5)
     @test 2950e0 == compute_density_ratio(PhaseRatio, rheologies, args)
+    @test 2950e0 == compute_density(rheologies, PhaseRatio, args)
+    
+    SvPhaseRatio = SA[0.5, 0.5]
+    @test 2950e0 == compute_density_ratio(SvPhaseRatio, rheologies, args)
+    @test 2950e0 == compute_density(rheologies, SvPhaseRatio, args)
 
 end


### PR DESCRIPTION
Extends `compute_param` to work with phase ratios given by `Ntuple`s and `StaticArrays` (i.e. compatible with `CellArrays`). Example:

```julia
using Test, GeoParams, StaticArrays
args = (P=0.0, T=20.0)
rheologies = (
        SetMaterialParams(;
            Name="Crust",
            Phase=0,
            CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e23Pas)),
            Density=ConstantDensity(; ρ=2900kg / m^3),
        ),
        SetMaterialParams(;
            Name="Lower Crust",
            Phase=1,
            CreepLaws=(PowerlawViscous(; n=5.0), LinearViscous(; η=1e21Pas)),
            Density=Compressible_Density(; ρ0=3000kg / m^3),
        )
)

PhaseRatio = (0.5, 0.5)
@test 2950e0 == compute_density(rheologies, PhaseRatio, args)
    
SvPhaseRatio = SA[0.5, 0.5]
@test 2950e0 == compute_density(rheologies, SvPhaseRatio, args)
```

