### PR TITLE
fix typos and add spell check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+      - name: Check spelling
+        uses: crate-ci/typos@v1.16.11

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,11 @@
+[default.extend-words]
+# single words that shall be ignored
+Wirth = "Wirth"
+Commun = "Commun"
+siz = "siz" # common name of sizes
+nd = "nd" # suffix for non-dimensionalized data
+
+[default.extend-identifiers]
+# group of words that shall be ignored
+x_nd = "x_nd"
+FeOt = "FeOt"

--- a/src/CompositeRheologies/CompositeRheologies_print.jl
+++ b/src/CompositeRheologies/CompositeRheologies_print.jl
@@ -1,6 +1,6 @@
 # Pretty printing for CompositeRheologies
 
-# returns a matrix wuth strings in the right order
+# returns a matrix with strings in the right order
 function print_rheology_matrix(v::Tuple)
 
     n = 40

--- a/src/Computations.jl
+++ b/src/Computations.jl
@@ -12,7 +12,7 @@ function compute_param!(
     return rho .= map(x -> fn(x, P, T), MatParam)
 end
 
-# each individual calcuation 
+# each individual calculation 
 function compute_param(
     fn::F, MatParam::NTuple{N,AbstractMaterialParamsStruct}, args
 ) where {F,N}

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -141,7 +141,7 @@ using GeoParams
 
     # test various calculations (using arrays with and without units)
     T_vec = (273K):(10K):(500K)        # using units
-    T = 400.0K               # Unitful quanity
+    T = 400.0K               # Unitful quantity
     T_nd = 10:10:200            # no units  
     α = GeoUnit(3e-5 / K)
     T₀ = GeoUnit(293K)


### PR DESCRIPTION
This setup will run a spell checker for every PR. I fixed the version of the spell checker to avoid letting PRs fail due to updates of it. Dependabot will automatically create PRs with updates of the spell checker. To reduce their frequency, I set up Dependabot to run monthly instead of weekly.

If you like this, we can set it up for other repos as well.