### PR TITLE
fix docstring of GeoParams

### DIFF
--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -1,4 +1,6 @@
 """
+    module GeoParams
+
 Typical geodynamic simulations involve a large number of material parameters that have units that are often inconvenient to be directly used in numerical models
 This package has two main features that help with this:
 - Create a nondimensionalization object, which can be used to transfer dimensional to non-dimensional parameters (usually better for numerical solvers)
@@ -7,7 +9,6 @@ This package has two main features that help with this:
 The material parameter object is designed to be extensible and can be passed on to the solvers, such that new creep laws or features can be readily added. 
 We also implement some typically used creep law parameters, together with tools to plot them versus and compare our results with those of published papers (to minimize mistakes). 
 """
-__precompile__()
 module GeoParams
 
 using Parameters        # helps setting default parameters in structures


### PR DESCRIPTION
The docstring was not attach directly to the module, so it wasn't found. I removed the `__precompile__()` call since it was just using the default setting (precompilation enabled), so it didn't have any other effect than removing the docstring.