### PR TITLE
Use a package extension for GLMakie-based functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -56,4 +56,3 @@ julia = "1.7"
 
 [extras]
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/Project.toml
+++ b/Project.toml
@@ -25,10 +25,17 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unidecode = "967fb449-e509-55aa-8007-234b4096b967"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[weakdeps]
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+
+[extensions]
+GeoParamsGLMakieExt = "GLMakie"
+
 [compat]
 BibTeX = "0.1"
 DelimitedFiles = "1.0"
 ForwardDiff = "0.10"
+GLMakie = "0.8"
 Interpolations = "0.13, 0.14"
 KernelDensitySJ = "0.2"
 LaTeXStrings = "1.2"
@@ -48,4 +55,5 @@ Unitful = "1.0"
 julia = "1.7"
 
 [extras]
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This package has three main objectives:
 - Create an object in which you can specify material parameters employed in the geodynamic simulations
 - Provide allocation-free computational routines for GPU and CPUs, that can be integrated in solvers, which replaces all point-wise calculations (to compute material parameters or equations of state, for example).
 
-The material parameter object is designed to be extensible and can be passed on to the solvers, such that new creep laws or features can be readily added. If you use the computational routines we provide, these new features are immediately available in all your codes (finite element, finite difference, AMR codes, etc.). 
+The material parameter object is designed to be extensible and can be passed on to the solvers, such that new creep laws or features can be readily added. If you use the computational routines we provide, these new features are immediately available in all your codes (finite element, finite difference, AMR codes, etc.).
 
-We also implement some typically used creep law parameters, together with tools to plot them versus and compare our results with those of published papers (to minimize mistakes).  
+We also implement some typically used creep law parameters, together with tools to plot them versus and compare our results with those of published papers (to minimize mistakes).
 
 NOTE: The package remains under development and the API is not yet fully fixed. Therefore feel free to look at it, but be aware that things may still change when you incorporate it into your codes. Comments/ideas/suggestions are highly apprecciated!
 
 ### Contents
-* [1. Nondimensionalization](#1-nondimensionalization) 
+* [1. Nondimensionalization](#1-nondimensionalization)
 * [2. Material parameters](#2-material-parameters)
 * [3. Plotting and output](#3-plotting-and-output)
 * [4. Computational engine](#4-computational-engine)
@@ -27,24 +27,24 @@ NOTE: The package remains under development and the API is not yet fully fixed. 
 * [8. Contributing](#8-contributing)
 * [9. Funding](#9-funding)
 
-### 1. Nondimensionalization 
+### 1. Nondimensionalization
 Typical geodynamic simulations involve dimensions on the order of 10's-1000's of kilometers, and viscosities on the order of ~1e20 Pas. If such values are directly employed in numerical solvers, they may result in roundoff errors. It is therefore common practice to nondimensionalize the input parameters by dividing them by typical values such that the result gives numbers that are closer to one.
-This can be done by specifying characteristic values for `length`, `stress`, `temperature` and `viscosity`. From these `basic` units all other physical units are derived and input parameters can thus be nondimensionalized accordingly (and dimensionalized again when plotting or saving output). 
+This can be done by specifying characteristic values for `length`, `stress`, `temperature` and `viscosity`. From these `basic` units all other physical units are derived and input parameters can thus be nondimensionalized accordingly (and dimensionalized again when plotting or saving output).
 
 As you learned in physics, the common approach to do this is by using `SI` units. Yet, as meters and seconds are not so convenient in geodynamics, where we usually deal with lengthscales on the orders of kilometers and timescales in millions of years, we also provide the `geo` object, which allows to give input parameters in more convenient units.
 
 ```julia
 julia> using GeoParams
 julia> CharDim = GEO_units(length=1000km, temperature=1000C, stress=10MPa, viscosity=1e20Pas)
-Employing GEO units 
-Characteristic values: 
+Employing GEO units
+Characteristic values:
          length:      1000 km
          time:        0.3169 Myrs
          stress:      10 MPa
          temperature: 1000.0 °C
 ```
 You can use 3 `types`:
-  1. *GEO* units: Units of length in the code are expected to be in kilometers, time is in million of years (Myrs) and stresses are in MPa (1e6 Pa). 
+  1. *GEO* units: Units of length in the code are expected to be in kilometers, time is in million of years (Myrs) and stresses are in MPa (1e6 Pa).
   2. *SI* units: all values are in SI units (meters, Pascal, seconds)
   3. *NONE*: all input parameters are in nondimensional units
 
@@ -64,9 +64,9 @@ or convert them to different units:
 julia> uconvert(Pa^-3.05*s^-1, A)
 3.157479571851836e-20 Pa⁻³·⁰⁵ s⁻¹
 ```
-### 2. Material parameters  
-  
-All geodynamic simulations require specifying material parameters, such as (nonlinear) viscous constitutive relationships or an equation of state. These parameters are usually specified per `phase`. Here, we provide a framework that simplifies doing that. Thanks to the flexibility of julia, we can actually directly embed the function that does the computations in the structure itself, which makes it straightforward to extend it and add new creep laws (which can directly be used in the solvers).  
+### 2. Material parameters
+
+All geodynamic simulations require specifying material parameters, such as (nonlinear) viscous constitutive relationships or an equation of state. These parameters are usually specified per `phase`. Here, we provide a framework that simplifies doing that. Thanks to the flexibility of julia, we can actually directly embed the function that does the computations in the structure itself, which makes it straightforward to extend it and add new creep laws (which can directly be used in the solvers).
 
 Some examples of where this is used:
 #### 2.1 Constant density, constant linear viscosity
@@ -76,64 +76,64 @@ julia> MatParam = SetMaterialParams(Name="Viscous Matrix", Phase=2,
                                      CreepLaws = LinearViscous(η=1e23Pa*s))
 Phase 2 : Viscous Matrix
         | [dimensional units]
-        | 
-        |-- Density           : Constant density: ρ=2900 kg m⁻³ 
-        |-- Gravity           : Gravitational acceleration: g=9.81 m s⁻² 
-        |-- CreepLaws         : Linear viscosity: η=1.0e23 Pa s 
+        |
+        |-- Density           : Constant density: ρ=2900 kg m⁻³
+        |-- Gravity           : Gravitational acceleration: g=9.81 m s⁻²
+        |-- CreepLaws         : Linear viscosity: η=1.0e23 Pa s
 ```
 The same but with non-dimensionalization of all parameters:
 ```julia
 julia> CharDim = GEO_units(length=1000km, temperature=1000C, stress=10MPa, viscosity=1e20Pas);
-julia> MatParam = SetMaterialParams(Name="Viscous Matrix", Phase=2, 
+julia> MatParam = SetMaterialParams(Name="Viscous Matrix", Phase=2,
                                      Density   = ConstantDensity(),
                                      CreepLaws = LinearViscous(η=1e23Pa*s), CharDim=CharDim)
 Phase 2 : Viscous Matrix
         | [non-dimensional units]
-        | 
-        |-- Density           : Constant density: ρ=2.8999999999999996e-18 
-        |-- Gravity           : Gravitational acceleration: g=9.81e20 
-        |-- CreepLaws         : Linear viscosity: η=999.9999999999998 
+        |
+        |-- Density           : Constant density: ρ=2.8999999999999996e-18
+        |-- Gravity           : Gravitational acceleration: g=9.81e20
+        |-- CreepLaws         : Linear viscosity: η=999.9999999999998
 ```
 You can define a tuple with phase information like this:
 
 ```julia
 julia> CharDim      = GEO_units(length=1000km, temperature=1000C, stress=10MPa, viscosity=1e20Pas);
-julia> MatParam     = ( SetMaterialParams(Name="Viscous Matrix", Phase=1, 
+julia> MatParam     = ( SetMaterialParams(Name="Viscous Matrix", Phase=1,
                                      Density   = ConstantDensity(),
                                      CreepLaws = LinearViscous(η=1e23Pa*s), CharDim=CharDim),
-                        SetMaterialParams(Name="Viscous Sinker", Phase=2, 
+                        SetMaterialParams(Name="Viscous Sinker", Phase=2,
                                      Density   = PT_Density(),
                                      CreepLaws = LinearViscous(η=1e21Pa*s), CharDim=CharDim)
                         );
 julia> MatParam
 Phase 1 : Viscous Matrix
         | [non-dimensional units]
-        | 
-        |-- Density           : Constant density: ρ=2.8999999999999996e-18 
-        |-- Gravity           : Gravitational acceleration: g=9.81e20 
-        |-- CreepLaws         : Linear viscosity: η=999.9999999999998 
+        |
+        |-- Density           : Constant density: ρ=2.8999999999999996e-18
+        |-- Gravity           : Gravitational acceleration: g=9.81e20
+        |-- CreepLaws         : Linear viscosity: η=999.9999999999998
 Phase 2 : Viscous Sinker
         | [non-dimensional units]
-        | 
-        |-- Density           : P/T-dependent density: ρ0=2.8999999999999996e-18, α=0.038194500000000006, β=0.01, T0=0.21454659702313156, P0=0.0 
-        |-- Gravity           : Gravitational acceleration: g=9.81e20 
-        |-- CreepLaws         : Linear viscosity: η=9.999999999999998                              
+        |
+        |-- Density           : P/T-dependent density: ρ0=2.8999999999999996e-18, α=0.038194500000000006, β=0.01, T0=0.21454659702313156, P0=0.0
+        |-- Gravity           : Gravitational acceleration: g=9.81e20
+        |-- CreepLaws         : Linear viscosity: η=9.999999999999998
 ```
 
 #### 2.2 Nonlinear creep laws
 You can add pre-defined non-linear creep laws as:
 ```julia
-julia> Phase = SetMaterialParams(Name="Viscous Matrix", Phase=2, 
+julia> Phase = SetMaterialParams(Name="Viscous Matrix", Phase=2,
                                                   Density   = ConstantDensity(),
                                                   CreepLaws = (SetDislocationCreep("Wet Olivine | Hirth & Kohlstedt (2003)"),
                                                               LinearViscous(η=1e23Pa*s)) )
 Phase 2 : Viscous Matrix
         | [dimensional units]
-        | 
-        |-- Density           : Constant density: ρ=2900.0 kg m⁻³·⁰ 
-        |-- Gravity           : Gravitational acceleration: g=9.81 m s⁻²·⁰ 
-        |-- CreepLaws         : DislocationCreep: Name = Wet Olivine | Hirth & Kohlstedt (2003), n=3.5, r=1.2, A=90.0, E=480.0, V=1.1e-5, Apparatus=1 
-        |                       Linear viscosity: η=1.0e23 
+        |
+        |-- Density           : Constant density: ρ=2900.0 kg m⁻³·⁰
+        |-- Gravity           : Gravitational acceleration: g=9.81 m s⁻²·⁰
+        |-- CreepLaws         : DislocationCreep: Name = Wet Olivine | Hirth & Kohlstedt (2003), n=3.5, r=1.2, A=90.0, E=480.0, V=1.1e-5, Apparatus=1
+        |                       Linear viscosity: η=1.0e23
 ```
 Note that the dictionary `DislocationCreep_info` has all pre-defined creep laws, so for an overview type:
 ```julia
@@ -145,21 +145,20 @@ Dict{String, DislocationCreep} with 2 entries:
 
 ### 3. Plotting and output
 
-A typical geodynamic simulation involves a lot of parameters. Creating data tables for scientific publications that describe all parameters employed is usually done by hand (and no-one really likes doing that). In our experience a lot of errors happen while doing this, either because the units are mixed up (some creep laws have weird units like MPa^{-n}), or because some parameters are forgotten. To help with this, we provide number of functions that 
+A typical geodynamic simulation involves a lot of parameters. Creating data tables for scientific publications that describe all parameters employed is usually done by hand (and no-one really likes doing that). In our experience a lot of errors happen while doing this, either because the units are mixed up (some creep laws have weird units like MPa^{-n}), or because some parameters are forgotten. To help with this, we provide number of functions that
   1)  Simplify creating plots in the same manner as in many publications that report the laboratory experiments used to create the creep laws. In that way, they can be directly compared to the original results. You can also create publication-ready figures.
-  2)  Provide tools to automatically generate data tables from the input parameters. This saves time and minimizes errors. 
-#### 3.1 Plotting 
+  2)  Provide tools to automatically generate data tables from the input parameters. This saves time and minimizes errors.
+#### 3.1 Plotting
 A few simple functions are provided to plot various parameters.
 For example, in order to plot a melting parameterisation, do:
 ```julia
-julia> using GeoParams, Plots
-Adding plotting routines of GeoParams
+julia> using GLMakie, GeoParams
 julia> p=MeltingParam_4thOrder();
 julia> PlotMeltFraction(p);
 ```
 
 #### 3.2 Automatically create data tables
-When writing scientific papers that describes numerical modelling results, it is usually necessary to include tables that lists all model parameters employed. Doing this is error-prone and usually not a very interesting job to do. 
+When writing scientific papers that describes numerical modelling results, it is usually necessary to include tables that lists all model parameters employed. Doing this is error-prone and usually not a very interesting job to do.
 That is why we provide routines that fully automatize this process:
 First, we need to define a phase.
 ```julia
@@ -185,20 +184,20 @@ compute_density!(Rho, MatParam, Phases, args)
 Here ```Rho``` is an array with densities, `MatParam` a tuple with material parameters as explained in [section #2](#2-material-parameters), `Phases` an array with integers which indicates which phase is present at every point, and `args` contains arguments to compute density (here: temperature and pressure). This computational routine works on the CPU, but also on the GPU (in combination with [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl)).
 Using a constant density, for example, can be specified with:
 ```julia
-MatParam = (SetMaterialParams(Name="Crust", Phase=0, 
-                Density   = ConstantDensity(ρ=2900kg/m^3)),) 
+MatParam = (SetMaterialParams(Name="Crust", Phase=0,
+                Density   = ConstantDensity(ρ=2900kg/m^3)),)
 ```
 Using a density that employs a phase diagram (which depends on pressure and temperature) can be invoked with:
 ```julia
-MatParam = (SetMaterialParams(Name="Mantle", Phase=0, 
+MatParam = (SetMaterialParams(Name="Mantle", Phase=0,
                 Density   = PerpleX_LaMEM_Diagram("test_data/Peridotite.in"), );
 ```
 
-Importantly, you *do not have to change your code* if you want to use a new density parameterisation, as implementing this in `GeoParams` is sufficient. 
-This makes it easy to use identical material parameters in a range of codes and eliminates the risk for making mistakes. It also saves a substantial amount of time in developing new codes as, in our experience, much of the debugging time is devoted to fixing bugs in the material parameters. 
+Importantly, you *do not have to change your code* if you want to use a new density parameterisation, as implementing this in `GeoParams` is sufficient.
+This makes it easy to use identical material parameters in a range of codes and eliminates the risk for making mistakes. It also saves a substantial amount of time in developing new codes as, in our experience, much of the debugging time is devoted to fixing bugs in the material parameters.
 
 ### 5. Installation
-You can install this package by specifying 
+You can install this package by specifying
 ```julia
 julia> ]
 pkg> add GeoParams
@@ -219,7 +218,7 @@ The key packages we rely on:
 - [Parameters.jl](https://github.com/mauro3/Parameters.jl) to have structures that are easier to modify
 - [LaTeXStrings.jl](https://github.com/stevengj/LaTeXStrings.jl) to be able to add equations to the structures that describe the employed material laws
 ### 8. Contributing
-Help with developing this package is highly appreciated. You can contribute for example by adding new creep laws or by adding new constitutive relationships. If you invest a bit of time now, it will save others in the community a lot of time! 
+Help with developing this package is highly appreciated. You can contribute for example by adding new creep laws or by adding new constitutive relationships. If you invest a bit of time now, it will save others in the community a lot of time!
 The simplest way to do this is by cloning the repository, and creating a new branch for your feature. Once you are happy with what you added (and after you added a test to ensure that it will keep working with future changes), create a pull request and we will evaluate & merge it.
 
 

--- a/docs/src/man/TASclassification.md
+++ b/docs/src/man/TASclassification.md
@@ -9,8 +9,8 @@ GeoParams.TASclassificationData
 
 # Computational routine
 There is one routine with which you can retrieve the index of the TAS rock-type. The routine receives as an input a compositional vector [SiO2,Na2O+K2O] in wt% and sends back an index [1-15].
-  
-        
+
+
 ```@docs
 GeoParams.computeTASclassification
 ```
@@ -21,5 +21,5 @@ Using the index of the rock-type you can get the name of the corresponding volca
 GeoParams.retrieveTASrockType
 ```
 
-We also provide a plotting routine, provided the `Plots` package is loaded, which produces figures such as:
+We also provide a plotting routine, provided the GLMakie.jl package is loaded, which produces figures such as:
 ![subet3](./assets/img/TAS_diagram.png)

--- a/docs/src/man/melting.md
+++ b/docs/src/man/melting.md
@@ -24,11 +24,11 @@ GeoParams.MeltingParam.compute_dϕdT!
 GeoParams.MeltingParam.compute_dϕdT
 ```
 
-Also note that phase diagrams can be imported using `PerpleX_LaMEM_Diagram`, which may also have melt content information. 
+Also note that phase diagrams can be imported using `PerpleX_LaMEM_Diagram`, which may also have melt content information.
 The computational routines work with that as well.
 
 # Plotting routines
-You can use the routine `PlotMeltFraction` to create a plot, provided that the `Plots` package has been loaded
+You can use the routine `PlotMeltFraction` to create a plot, provided that the `GLMakie` package has been loaded
 ```@docs
 GeoParams.PlotMeltFraction
 ```

--- a/docs/src/man/zirconages.md
+++ b/docs/src/man/zirconages.md
@@ -1,7 +1,7 @@
 # Zircon age parameterizations
 
 # Methods
-Zircons are one of the ways in which we can date the age & activity of magmatic systems. 
+Zircons are one of the ways in which we can date the age & activity of magmatic systems.
 Here, we provide a computational routine that computes the zircon age distribution from temperature-time paths
 
 ```@docs
@@ -20,5 +20,5 @@ GeoParams.compute_zircons_Ttpath
 GeoParams.zircon_age_PDF
 ```
 
-We also provide a plotting routine, provided the `Plots` package is loaded, which produces figures such as:
+We also provide a plotting routine, provided the GLMakie.jl package is loaded, which produces figures such as:
 ![subet3](./assets/img/ZirconAge_PDF.png)

--- a/ext/GeoParamsGLMakieExt.jl
+++ b/ext/GeoParamsGLMakieExt.jl
@@ -1,0 +1,16 @@
+# Package extension for adding GLMakie-based features to GeoParams.jl
+module GeoParamsGLMakieExt
+
+# We do not check `isdefined(Base, :get_extension)` as recommended since
+# Julia v1.9.0 does not load package extensions when their dependency is
+# loaded from the main environment.
+if VERSION >= v"1.9.1"
+  using GLMakie
+else
+  using ..GLMakie
+end
+
+include("../src/Plotting/Plotting.jl")
+include("../src/Plotting/StrengthEnvelope.jl")
+
+end # module

--- a/src/Energy/Conductivity.jl
+++ b/src/Energy/Conductivity.jl
@@ -2,7 +2,7 @@ module Conductivity
 
 # This implements different methods to specify conductivity of rocks
 #
-# If you want to add a new method here, feel free to do so. 
+# If you want to add a new method here, feel free to do so.
 # Remember to also export the function name in GeoParams.jl (in addition to here)
 
 using Parameters, LaTeXStrings, Unitful
@@ -28,9 +28,9 @@ include("../Computations.jl")
 # Constant Conductivity -------------------------------------------------------
 """
     ConstantConductivity(k=3.0W/m/K)
-    
+
 Set a constant conductivity
-```math  
+```math
     k  = cst
 ```
 where ``k`` is the thermal conductivity [``W/m/K``].
@@ -64,13 +64,13 @@ compute_conductivity(s::ConstantConductivity, I::Integer...) = s(I...)
 """
     compute_conductivity(k_array::AbstractArray{<:AbstractFloat,N},P::AbstractArray{<:AbstractFloat,N},T::AbstractArray{<:AbstractFloat,N}, s::ConstantConductivity) where N
 
-In-place routine to compute constant conductivity    
+In-place routine to compute constant conductivity
 """
 function compute_conductivity!(
     k_array::AbstractArray{_T,N}, s::ConstantConductivity; kwargs...
 ) where {_T, N} end
 
-# Print info 
+# Print info
 function show(io::IO, g::ConstantConductivity)
     return print(io, "Constant conductivity: k=$(g.k.val)")
 end
@@ -79,19 +79,19 @@ end
 # Temperature dependent conductivity -------------------------------
 """
     T_Conductivity_Whittington()
-    
-Sets a temperature-dependent conductivity following the parameterization of *Whittington, A.G., Hofmeister, A.M., Nabelek, P.I., 2009. Temperature-dependent thermal diffusivity of the Earth’s crust and implications for magmatism. Nature 458, 319–321. https://doi.org/10.1038/nature07818.* 
-Their parameterization is originally given for the thermal diffusivity, together with a parameterization for thermal conductivity, which allows us to compute 
-```math  
-    Cp = a + b T - c/T^2 
+
+Sets a temperature-dependent conductivity following the parameterization of *Whittington, A.G., Hofmeister, A.M., Nabelek, P.I., 2009. Temperature-dependent thermal diffusivity of the Earth’s crust and implications for magmatism. Nature 458, 319–321. https://doi.org/10.1038/nature07818.*
+Their parameterization is originally given for the thermal diffusivity, together with a parameterization for thermal conductivity, which allows us to compute
+```math
+    Cp = a + b T - c/T^2
 ```
-```math  
+```math
     \\kappa = d/T - e \\textrm{ if } T<=846K
 ```
-```math  
+```math
     \\kappa = f - g*T \\textrm{ if } T>846K
 ```
-```math    
+```math
     \\rho = 2700 kg/m^3
 ```
 ```math
@@ -105,10 +105,10 @@ where ``Cp`` is the heat capacity [``J/mol/K``], and ``a,b,c`` are parameters th
 - b = 0.0323J/mol/K^2   if T> 846 K
 - c = 5e6J/mol*K        if T<= 846 K
 - c = 47.9e-6J/mol*K    if T> 846 K
-- d = 576.3m^2/s*K      
-- e = 0.062m^2/s        
-- f = 0.732m^2/s        
-- g = 0.000135m^2/s/K 
+- d = 576.3m^2/s*K
+- e = 0.062m^2/s
+- f = 0.732m^2/s
+- g = 0.000135m^2/s/K
 
 This looks like:
 
@@ -117,7 +117,7 @@ This looks like:
 Example
 ===
 ```julia
-julia> using GeoParams, Plots
+julia> using GLMakie, GeoParams
 julia> p=T_Conductivity_Whittington();
 julia> T,k,plt = PlotConductivity(p)
 ```
@@ -126,14 +126,14 @@ julia> T,k,plt = PlotConductivity(p)
 """
 @with_kw_noshow struct T_Conductivity_Whittington{T,U1,U2,U3,U4,U5,U6,U7,U8,U9} <:
                        AbstractConductivity{T}
-    # Note: the resulting curve of k was visually compared with Fig. 2 of the paper  
+    # Note: the resulting curve of k was visually compared with Fig. 2 of the paper
     a0::GeoUnit{T,U1} = 199.5J / mol / K                # prefactor for low T       (T<= 846 K)
     a1::GeoUnit{T,U1} = 229.32J / mol / K               # prefactor for high T      (T>  846 K)
     b0::GeoUnit{T,U2} = 0.0857J / mol / K^2             # linear term for low T     (T<= 846 K)
     b1::GeoUnit{T,U2} = 0.0323J / mol / K^2             # linear term for high T    (T>  846 K)
     c0::GeoUnit{T,U3} = 5e6J / mol * K                  # quadratic term for low T  (T<= 846 K)
     c1::GeoUnit{T,U3} = 47.9e-6J / mol * K              # quadratic term for high T (T>  846 K)
-    molmass::GeoUnit{T,U4} = 0.22178kg / mol               # average molar mass 
+    molmass::GeoUnit{T,U4} = 0.22178kg / mol               # average molar mass
     Tcutoff::GeoUnit{T,U5} = 846.0K                      # cutoff temperature
     rho::GeoUnit{T,U6} = 2700kg / m^3                  # Density they use for an average crust
     d::GeoUnit{T,U7} = 576.3 * 1e-6m^2 / s * K           # diffusivity parameterization
@@ -200,11 +200,11 @@ end
 """
     compute_conductivity!(k_array::AbstractArray{<:AbstractFloat,N},P::AbstractArray{<:AbstractFloat,N},T::AbstractArray{<:AbstractFloat,N}, s::T_Conductivity_Whittington) where N
 
-In-place routine to compute temperature-dependent conductivity    
+In-place routine to compute temperature-dependent conductivity
 """
 # function compute_conductivity!(k::AbstractArray{_T,N}, s::T_Conductivity_Whittington{_T}; T::AbstractArray{_T,N}, kwargs...) where {_T,N} end
 
-# Print info 
+# Print info
 function show(io::IO, g::T_Conductivity_Whittington) #info about the struct
     return print(
         io,
@@ -216,8 +216,8 @@ end
 # Temperature dependent conductivity -------------------------------
 """
     T_Conductivity_Whittington_parameterised()
-    
-Sets a temperature-dependent conductivity that is  parameterization after *Whittington, et al.  2009* 
+
+Sets a temperature-dependent conductivity that is  parameterization after *Whittington, et al.  2009*
 
 The original parameterization involves quite a few parameters; this is a polynomial fit that is roughly valid from 0-1000 Celsius
 ```math
@@ -235,11 +235,11 @@ The comparison of this parameterisation vs. the original one is:
 """
 @with_kw_noshow struct T_Conductivity_Whittington_parameterised{T,U1,U2,U3,U4,U5} <:
                        AbstractConductivity{T}
-    # Note: the resulting curve of k was visually compared with Fig. 2 of the paper  
-    a::GeoUnit{T,U1} = -2e-09Watt / m / K^4                # 
-    b::GeoUnit{T,U2} = 6e-06Watt / m / K^3              # 
-    c::GeoUnit{T,U3} = -0.0062Watt / m / K^2              # 
-    d::GeoUnit{T,U4} = 4Watt / m / K                # 
+    # Note: the resulting curve of k was visually compared with Fig. 2 of the paper
+    a::GeoUnit{T,U1} = -2e-09Watt / m / K^4                #
+    b::GeoUnit{T,U2} = 6e-06Watt / m / K^3              #
+    c::GeoUnit{T,U3} = -0.0062Watt / m / K^2              #
+    d::GeoUnit{T,U4} = 4Watt / m / K                #
     Ts::GeoUnit{T,U5} = 273.15 * K                    # Temperature shift [C->K]
 end
 function T_Conductivity_Whittington_parameterised(args...)
@@ -277,7 +277,7 @@ function (s::T_Conductivity_Whittington_parameterised)(T::AbstractArray; kwargs.
 
     @inbounds for i in eachindex(T)
         # Note: in general, we operate with SI units or the non-dimensional equivalent of that
-        # This parameterisation was developed 
+        # This parameterisation was developed
         T_C = T[i] - Ts
         k[i] = a * T_C^3 + b * T_C^2 + c * T_C + d
     end
@@ -295,11 +295,11 @@ end
 """
     compute_conductivity!(k::AbstractArray{_T,N}, s::T_Conductivity_Whittington_parameterised{_T}, P::AbstractArray{_T,N}, T::AbstractArray{_T,N})
 
-In-place routine to compute temperature-dependent conductivity    
+In-place routine to compute temperature-dependent conductivity
 """
 # function compute_conductivity!(k::AbstractArray{_T,N}, s::T_Conductivity_Whittington_parameterised{_T}; T::AbstractArray{_T,N}, kwargs...) where {_T,N} end
 
-# Print info 
+# Print info
 function show(io::IO, g::T_Conductivity_Whittington_parameterised) #info about the struct
     return print(
         io,
@@ -311,19 +311,19 @@ end
 # Temperature (& Pressure) dependent conductivity -------------------------------
 """
     TP_Conductivity()
-    
-Sets a temperature (and pressure)-dependent conductivity parameterization as described in Gerya, Numerical Geodynamics (2nd edition, Table 21.2).
-The general for  
 
-```math  
-    k = \\left( a_k +  {b_k \\over {T + c_k}} \\right) (1 + d_k P) 
+Sets a temperature (and pressure)-dependent conductivity parameterization as described in Gerya, Numerical Geodynamics (2nd edition, Table 21.2).
+The general for
+
+```math
+    k = \\left( a_k +  {b_k \\over {T + c_k}} \\right) (1 + d_k P)
 ```
 
 where ``k`` is the conductivity [``W/K/m``], and ``a_k,b_k,c_k,d_k`` are parameters that dependent on the temperature `T` and pressure `P`:
-- ``a_k`` = 1.18Watt/K/m    
-- ``b_k`` = 474Watt/m 
-- ``c_k`` = 77K       
-- ``d_k`` = 0/MPa       
+- ``a_k`` = 1.18Watt/K/m
+- ``b_k`` = 474Watt/m
+- ``c_k`` = 77K
+- ``d_k`` = 0/MPa
 """
 @with_kw_noshow struct TP_Conductivity{T,N,U1,U2,U3,U4} <: AbstractConductivity{T}
     Name::NTuple{N,Char} = ""                  # The name is encoded as a NTuple{Char} to make it isbits
@@ -349,17 +349,17 @@ end
 
 """
     Set_TP_Conductivity["Name of temperature(-pressure) dependent conductivity"]
-    
+
 This is a dictionary with pre-defined laws:
-- "UpperCrust"    
+- "UpperCrust"
 - "LowerCrust"
 - "OceanicCrust"
 - "Mantle"
 
 # Example
-```julia 
+```julia
 julia> k=Set_TP_Conductivity["Mantle"]
-T/P dependent conductivity: k = (0.73 W K⁻¹ m⁻¹ + 1293 W m⁻¹/(T + 77 K))*(1 + 4.0e-5 MPa⁻¹*P)  
+T/P dependent conductivity: k = (0.73 W K⁻¹ m⁻¹ + 1293 W m⁻¹/(T + 77 K))*(1 + 4.0e-5 MPa⁻¹*P)
 ```
 
 """
@@ -477,7 +477,7 @@ for myType in (
     end
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::TP_Conductivity)
     if ustrip(Value(g.d)) == 0
         print(
@@ -504,7 +504,7 @@ Currently available:
 - T\\_Conductivity_Whittington
 - TP\\_Conductivity
 
-# Example 
+# Example
 Using dimensional units
 ```julia
 julia> T  = (250:100:1250)*K;
@@ -530,7 +530,7 @@ Returns conductivity if we are sure that we will only employ constant values thr
 """
 #compute_conductivity(s::ConstantConductivity) =  compute_conductivity(s,0,0)
 
-# Computational routines needed for computations with the MaterialParams structure 
+# Computational routines needed for computations with the MaterialParams structure
 function compute_conductivity(s::AbstractMaterialParamsStruct, args)
     return s.Conductivity[1](args)
 end

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -4,16 +4,16 @@ This package has two main features that help with this:
 - Create a nondimensionalization object, which can be used to transfer dimensional to non-dimensional parameters (usually better for numerical solvers)
 - Create an object in which you can specify material parameters employed in the geodynamic simulations
 
-The material parameter object is designed to be extensible and can be passed on to the solvers, such that new creep laws or features can be readily added. 
-We also implement some typically used creep law parameters, together with tools to plot them versus and compare our results with those of published papers (to minimize mistakes). 
+The material parameter object is designed to be extensible and can be passed on to the solvers, such that new creep laws or features can be readily added.
+We also implement some typically used creep law parameters, together with tools to plot them versus and compare our results with those of published papers (to minimize mistakes).
 """
 __precompile__()
 module GeoParams
 
-using Parameters        # helps setting default parameters in structures
-using Unitful           # Units
-using BibTeX            # references of creep laws
-using Requires          # To only add plotting routines if Plots is loaded
+using Parameters         # helps setting default parameters in structures
+using Unitful            # Units
+using BibTeX             # references of creep laws
+using Requires: @require # To only add plotting routines if GLMakie is loaded
 using StaticArrays
 using LinearAlgebra
 
@@ -32,7 +32,7 @@ export @u_str,
     upreffered,
     unit,
     ustrip,
-    NoUnits,  #  Units 
+    NoUnits,  #  Units
     GeoUnit,
     GeoUnits,
     GEO_units,
@@ -77,10 +77,10 @@ export @u_str,
 
 export AbstractGeoUnit1, GeoUnit1
 
-#         
-abstract type AbstractMaterialParam end                                    # structure that holds material parameters (density, elasticity, viscosity)          
-abstract type AbstractMaterialParamsStruct end                             # will hold all info for a phase       
-abstract type AbstractPhaseDiagramsStruct <: AbstractMaterialParam end    # will hold all info for phase diagrams 
+#
+abstract type AbstractMaterialParam end                                    # structure that holds material parameters (density, elasticity, viscosity)
+abstract type AbstractMaterialParamsStruct end                             # will hold all info for a phase
+abstract type AbstractPhaseDiagramsStruct <: AbstractMaterialParam end    # will hold all info for phase diagrams
 abstract type AbstractConstitutiveLaw{T} <: AbstractMaterialParam end
 abstract type AbstractComposite <: AbstractMaterialParam end
 
@@ -93,7 +93,7 @@ include("Utils.jl")
 include("TensorAlgebra/TensorAlgebra.jl")
 export second_invariant, second_invariant_staggered, rotate_elastic_stress
 
-# note that this throws a "Method definition warning regarding superscript"; that is expected & safe 
+# note that this throws a "Method definition warning regarding superscript"; that is expected & safe
 #  as we add a nicer way to create output of superscripts. I have been unable to get rid of this warning,
 #  as I am indeed redefining a method originally defined in Unitful
 include("Units.jl")
@@ -130,7 +130,7 @@ export compute_density,                                # computational routines
 
 # Constitutive relationships laws
 using .MaterialParameters.ConstitutiveRelationships
-export AxialCompression, SimpleShear, Invariant 
+export AxialCompression, SimpleShear, Invariant
 
 const get_shearmodulus = get_G
 const get_bulkmodulus = get_Kb
@@ -176,10 +176,10 @@ export dεII_dτII,
     SetConstantElasticity,
     effective_εII,
     iselastic,
-    get_G, 
+    get_G,
     get_Kb,
-    get_shearmodulus, 
-    get_bulkmodulus, 
+    get_shearmodulus,
+    get_bulkmodulus,
 
     #       Plasticity
     AbstractPlasticity,
@@ -191,7 +191,7 @@ export dεII_dτII,
     ∂Q∂τ,
     ∂Q∂P,∂Q∂τII,
     ∂F∂τII,∂F∂P,∂F∂λ,
-    
+
     #       Composite rheologies
     AbstractConstitutiveLaw,
     AbstractComposite,
@@ -200,7 +200,7 @@ export dεII_dτII,
     computeViscosity_τII!,
     computeViscosity_εII!,
     computeViscosity_εII_AD,
-    local_iterations_εII,    
+    local_iterations_εII,
     local_iterations_εII_AD,
     local_iterations_τII,
     local_iterations_τII_AD,
@@ -212,9 +212,9 @@ export dεII_dτII,
     create_rheology_string, print_rheology_matrix,
     compute_εII_harmonic, compute_τII_AD,
     isplastic,isvolumetricplastic,
-    compute_p_τII, 
-    local_iterations_εvol, 
-    compute_p_harmonic 
+    compute_p_τII,
+    local_iterations_εvol,
+    compute_p_harmonic
 
 # Constitutive relationships laws
 include("StressComputations/StressComputations.jl")
@@ -235,7 +235,7 @@ using .MaterialParameters.GravitationalAcceleration
 export compute_gravity,                                # computational routines
     ConstantGravity
 
-# Energy parameters: Heat Capacity, Thermal conductivity, latent heat, radioactive heat         
+# Energy parameters: Heat Capacity, Thermal conductivity, latent heat, radioactive heat
 using .MaterialParameters.HeatCapacity
 export compute_heatcapacity,
     compute_heatcapacity!, ConstantHeatCapacity, T_HeatCapacity_Whittington
@@ -304,16 +304,53 @@ include("Tables.jl")
 using .Tables
 export detachFloatfromExponent, Phase2Dict, Dict2LatexTable, Phase2DictMd, Dict2MarkdownTable, ParameterTable
 
-# Add plotting routines - only activated if the "Plots.jl" package is loaded 
 # Add 1D Strength Envelope
 include("./StrengthEnvelope/StrengthEnvelope.jl")
 
-# Add plotting routines - only activated if the "GLMakie.jl" package is loaded 
+# Add plotting routines - only activated if the "GLMakie.jl" package is loaded
+#
+# Add function definitions here such that they can be exported from GeoParams.jl
+# and extended in the GeoParamsGLMakieExt package extension or by the
+# GLMakie-specific code loaded by Requires.jl
+function PlotStrainrateStress end
+function PlotStressStrainrate end
+function PlotStrainrateViscosity end
+function PlotStressViscosity end
+function PlotHeatCapacity end
+function PlotConductivity end
+function PlotMeltFraction end
+function PlotPhaseDiagram end
+function Plot_TAS_diagram end
+function Plot_ZirconAge_PDF end
+function PlotDeformationMap end
+function PlotStressTime_0D end
+function PlotPressureStressTime_0D end
+function StrengthEnvelopePlot end
+
+export PlotStrainrateStress,
+    PlotStressStrainrate,
+    PlotStrainrateViscosity,
+    PlotStressViscosity,
+    PlotHeatCapacity,
+    PlotConductivity,
+    PlotMeltFraction,
+    PlotPhaseDiagram,
+    Plot_TAS_diagram,
+    Plot_ZirconAge_PDF,
+    PlotDeformationMap,
+    PlotStressTime_0D,
+    PlotPressureStressTime_0D,
+    StrengthEnvelopePlot
+
+# We do not check `isdefined(Base, :get_extension)` as recommended since
+# Julia v1.9.0 does not load package extensions when their dependency is
+# loaded from the main environment.
 function __init__()
-    @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" begin
-        print("Adding plotting routines of GeoParams through GLMakie \n")
-        @eval include("Plotting/Plotting.jl")
-        @eval include("Plotting/StrengthEnvelope.jl")
+    @static if !(VERSION >= v"1.9.1")
+        @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" begin
+            print("Adding plotting routines of GeoParams through GLMakie \n")
+            @eval include("../ext/GeoParamsGLMakieExt.jl")
+        end
     end
 end
 

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -1,6 +1,6 @@
 module MeltingParam
 
-# If you want to add a new method here, feel free to do so. 
+# If you want to add a new method here, feel free to do so.
 # Remember to also export the function name in GeoParams.jl (in addition to here)
 
 using Parameters, LaTeXStrings, Unitful
@@ -15,7 +15,7 @@ abstract type AbstractMeltingParam{T} <: AbstractMaterialParam end
 
 export compute_meltfraction,
     compute_meltfraction!,    # calculation routines
-    compute_dϕdT,             # derivative of melt fraction versus 
+    compute_dϕdT,             # derivative of melt fraction versus
     compute_dϕdT!,
     param_info,
     MeltingParam_Caricchi,
@@ -31,12 +31,12 @@ include("../Computations.jl")
 # Caricchi  -------------------------------------------------------
 """
     MeltingParam_Caricchi()
-    
-Implements the T-dependent melting parameterisation used by Caricchi, Simpson et al. (as for example described in Simpson) 
-```math  
-    \\theta = {(a - (T + c)) \\over b} 
+
+Implements the T-dependent melting parameterisation used by Caricchi, Simpson et al. (as for example described in Simpson)
+```math
+    \\theta = {(a - (T + c)) \\over b}
 ```
-```math  
+```math
     \\phi_{melt} = {1.0 \\over (1.0 + e^\\theta)}
 ```
 
@@ -97,7 +97,7 @@ function compute_dϕdT(p::MeltingParam_Caricchi; T, kwargs...)
     return dϕdT
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::MeltingParam_Caricchi)
     return print(io, "Caricchi et al. melting parameterization")
 end
@@ -106,15 +106,15 @@ end
 # MeltingParam_5thOrder  -------------------------------------------------------
 """
     MeltingParam_5thOrder(a,b,c,d,e,f,T_s,T_l)
-    
+
 Uses a 5th order polynomial to describe the melt fraction `phi` between solidus temperature `T_s` and liquidus temperature `T_l`
-```math  
+```math
     \\phi = a T^5 + b T^4 + c T^3 + d T^2 + e T + f  \\textrm{   for   } T_s ≤ T ≤ T_l
 ```
-```math  
+```math
     \\phi = 1  \\textrm{   if   } T>T_l
 ```
-```math  
+```math
     \\phi = 0  \\textrm{   if   } T<T_s
 ```
 Temperature `T` is in Kelvin.
@@ -179,7 +179,7 @@ function compute_dϕdT(p::MeltingParam_5thOrder; T, kwargs...)
     return dϕdT
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::MeltingParam_5thOrder)
     return print(
         io,
@@ -191,15 +191,15 @@ end
 # MeltingParam_4thOrder  -------------------------------------------------------
 """
     MeltingParam_4thOrder(b,c,d,e,f,T_s,T_l)
-    
+
 Uses a 4th order polynomial to describe the melt fraction `phi` between solidus temperature `T_s` and liquidus temperature `T_l`
-```math  
+```math
     \\phi = b T^4 + c T^3 + d T^2 + e T + f  \\textrm{   for   } T_s ≤ T ≤ T_l
 ```
-```math  
+```math
     \\phi = 1 \\textrm{   if   } T>T_l
 ```
-```math  
+```math
     \\phi = 0  \\textrm{   if   } T<T_s
 ```
 Temperature `T` is in Kelvin.
@@ -270,7 +270,7 @@ function compute_dϕdT!(
     return nothing
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::MeltingParam_4thOrder)
     return print(
         io,
@@ -282,16 +282,16 @@ end
 # MeltingParam_Quadratic  -------------------------------------------------------
 """
     MeltingParam_Quadratic(T_s,T_l)
-    
+
 Quadratic melt fraction parameterisation where melt fraction ``\\phi`` depends only on solidus (``T_s``) and liquidus (``T_l``) temperature:
-```math  
+```math
     \\phi = 1.0 - \\left( {T_l - T} \\over {T_l - T_s} \\right)^2
 ```
-```math  
-    \\phi = 1.0 \\textrm{ if } T>T_l 
+```math
+    \\phi = 1.0 \\textrm{ if } T>T_l
 ```
-```math  
-    \\phi = 0.0 \\textrm{ if } T<T_s 
+```math
+    \\phi = 0.0 \\textrm{ if } T<T_s
 ```
 Temperature `T` is in Kelvin.
 
@@ -344,7 +344,7 @@ function compute_dϕdT(p::MeltingParam_Quadratic; T, kwargs...)
     return dϕdT
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::MeltingParam_Quadratic)
     return print(
         io,
@@ -356,31 +356,31 @@ end
 # MeltingParam_Assimilation  -------------------------------------------------------
 """
     MeltingParam_Assimilation(T_s,T_l,a)
-    
+
 Melt fraction parameterisation that takes the assimilation of crustal host rocks into account, as used by Tierney et al. (2016) based upon a parameterisation of Spera and Bohrson (2001)
 
 Here, the fraction of molten and assimilated host rocks ``\\phi`` depends on the solidus (``T_s``) and liquidus (``T_l``) temperatures of the rocks, as well as on a parameter ``a=0.005``
-```math  
+```math
     X = \\left( {T - T_s} \\over {T_l - T_s} \\right)
 ```
-```math  
+```math
     \\phi = a \\cdot \\left( \\exp^{2ln(100)X} - 1.0 \\right) \\textrm{ if } X ≤ 0.5
 ```
-```math  
+```math
     \\phi = 1- a \\cdot \\exp^{2ln(100)(1-X)}  \\textrm{ if } X > 0.5
 ```
-```math  
-    \\phi = 1.0 \\textrm{ if } T>T_l 
+```math
+    \\phi = 1.0 \\textrm{ if } T>T_l
 ```
-```math  
-    \\phi = 0.0 \\textrm{ if } T<T_s 
+```math
+    \\phi = 0.0 \\textrm{ if } T<T_s
 ```
 Temperature `T` is in Kelvin.
 
 ![MeltingParam_Assimilation](./assets/img/MeltingParam_Assimilation.png)
 
 This was used, among others, in Tierney et al. (2016), who employed as default parameters:
-```math  
+```math
    T_s=973.15, T_l=1173.15, a=0.005
 ```
 
@@ -461,7 +461,7 @@ function compute_dϕdT(p::MeltingParam_Assimilation; T, kwargs...)
     return dϕdT
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::MeltingParam_Assimilation)
     return print(
         io, "Quadratic melting assimilation parameterisation after Spera & Bohrson (2001)"
@@ -473,22 +473,22 @@ end
 # Smooth melting function ------------------------------------------------
 
 """
-    SmoothMelting(; p=MeltingParam_4thOrder(), k_sol=0.2/K,  k_liq=0.2/K) 
+    SmoothMelting(; p=MeltingParam_4thOrder(), k_sol=0.2/K,  k_liq=0.2/K)
 
 This smoothens the melting parameterisation ``p`` around the solidus ``T_{sol}`` and liquidus ``T_{liq}``
 using a smoothened Heaviside step functions for the solidus:
-        
-```math  
+
+```math
     H_{sol} =  {1.0 \\over { 1 + \\exp( -2 k_{sol} (T - T_{sol} - {2 \\over k_{sol}}) )  }}
-```        
-and liquidus:        
-```math  
+```
+and liquidus:
+```math
     H_{liq} =  1.0 - {1.0 \\over { 1 + \\exp( -2 k_{liq} (T - T_{liq} + {2 \\over k_{liq}}) )  }}
-```  
+```
 The resulting melt fraction ``\\phi`` is computed from the original melt fraction ``\\phi_0`` (computed using one of the methods above) as:
-```math  
+```math
     \\phi =  \\phi_0 H_{sol} H_{liq} + 1.0 - H_{liq}
-``` 
+```
 The width of the smoothening zones is controlled by ``k_{sol}, k_{liq}`` (larger values = sharper boundary).
 
 This is important, as jumps in the derivative ``dϕ/dT`` can cause numerical instabilities in latent heat computations, which is prevented with this smoothening.
@@ -498,7 +498,7 @@ Example
 
 Let's consider a 4th order parameterisation:
 ```julia
-julia> using GeoParams, Plots
+julia> using GLMakie, GeoParams
 julia> p = MeltingParam_4thOrder();
 julia> T= collect(650.0:1:1050.) .+ 273.15;
 julia> T,phi,dϕdT =  PlotMeltFraction(p,T=T);
@@ -585,7 +585,7 @@ function compute_dϕdT(param::SmoothMelting; T, kwargs...)
         (-1.0 / ((1.0 + exp(-2k_liq * (T + 2 / k_liq - T_l)))^2)) *
         exp(-2k_liq * (T + 2 / k_liq - T_l))
 
-    # melt fraction & derivative 
+    # melt fraction & derivative
     dϕdT = compute_dϕdT(param.p; T=T)
     ϕ = param.p(; T, kwargs...)
 
@@ -598,7 +598,7 @@ function compute_dϕdT(param::SmoothMelting; T, kwargs...)
     return dϕdT_tot
 end
 
-# Print info 
+# Print info
 function show(io::IO, g::SmoothMelting)
     param = show(io, g.p)
     return print(
@@ -683,7 +683,7 @@ for myType in (
     end
 end
 
-# Computational routines needed for computations with the MaterialParams structure 
+# Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
         return zero(typeof(args).types[1])

--- a/src/Plotting/Plotting.jl
+++ b/src/Plotting/Plotting.jl
@@ -1,23 +1,7 @@
-"""
-    This provides a few plotting routines, for example, for CreepLaws
-"""
+# This provides a few plotting routines, for example, for CreepLaws
 
-using Unitful
-using Parameters
-using ..Units
-using ..MaterialParameters
-using ..MeltingParam
-using .GLMakie
-
-using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
-using .MaterialParameters.ConstitutiveRelationships
-using .MaterialParameters.HeatCapacity: AbstractHeatCapacity, compute_heatcapacity
-using .MaterialParameters.Conductivity: AbstractConductivity, compute_conductivity
-using .MeltingParam: AbstractMeltingParam, compute_meltfraction
-
-#Makie.inline!(true)
-
-export PlotStrainrateStress,
+# These functions are implemented in this file
+import GeoParams: PlotStrainrateStress,
     PlotStressStrainrate,
     PlotStrainrateViscosity,
     PlotStressViscosity,
@@ -31,12 +15,29 @@ export PlotStrainrateStress,
     PlotStressTime_0D,
     PlotPressureStressTime_0D
 
+# Make all `export`ed names from GeoParams.jl available
+using GeoParams
+# We also need the following un-`export`ed names
+using GeoParams: AbstractTempStruct
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
+using GeoParams.MaterialParameters.ConstitutiveRelationships
+using GeoParams.MaterialParameters.HeatCapacity: AbstractHeatCapacity, compute_heatcapacity
+using GeoParams.MaterialParameters.Conductivity: AbstractConductivity, compute_conductivity
+using GeoParams.MeltingParam: AbstractMeltingParam, compute_meltfraction
+
+using GeoParams.Units
+using GeoParams.MaterialParameters
+using GeoParams.MeltingParam
+
+using Unitful
+using Parameters
+
 """
-    fig, ax, εII,τII = PlotStrainrateStress(x; Strainrate=(1e-18,1e-12), args =(T=1000.0, P=0.0, d=1e-3, f=1.0), 
-                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="", 
+    fig, ax, εII,τII = PlotStrainrateStress(x; Strainrate=(1e-18,1e-12), args =(T=1000.0, P=0.0, d=1e-3, f=1.0),
+                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="",
                                             fig=nothing, filename=nothing, res=(1200, 1200), legendsize=15, labelsize=35)
-                                            
-Plots deviatoric stress versus deviatoric strain rate for a single or multiple creeplaws 
+
+Plots deviatoric stress versus deviatoric strain rate for a single or multiple creeplaws
     Note: if you want to create plots you need to install and load the `GLMakie.jl` package in julia.
 
 
@@ -49,7 +50,7 @@ julia> pp1 = SetDislocationCreep("Dry Anorthite | Rybacki et al. (2006)");
 ```
 Next you can define each of the creeplaws inidvidually, plus a combined diffusion & dislocation creep law:
 ```julia-repl
-julia> v   = (pp,pp1,(pp,pp1));   
+julia> v   = (pp,pp1,(pp,pp1));
 ```
 Next, define temperature to be `900K` and grainsize to be `100 μm` and create a default plot of the 3 mechanisms:
 ```julia-repl
@@ -58,9 +59,9 @@ julia> args=(T=900.0, d=100e-6)
 julia> PlotStrainrateStress(v, args=args, Strainrate=(1e-22,1e-15));
 ```
 
-We have quite a few options to customize the look & feel of the plot: 
+We have quite a few options to customize the look & feel of the plot:
 ```julia-repl
-julia> fig,ax,εII,τII = PlotStrainrateStress(v, args=args, Strainrate=(1e-22,1e-15), 
+julia> fig,ax,εII,τII = PlotStrainrateStress(v, args=args, Strainrate=(1e-22,1e-15),
                                             color=(:red,:blue,:green), linewidth=(1,1,3), linestyle=(:dash,:dash,:solid), label=("diffusion creep","dislocation creep","diffusion+dislocation creep"),
                                             title="Dry Anorthite after Rybacki et al. (2006) for T=900K, d=100μm");
 ```
@@ -123,7 +124,7 @@ function PlotStrainrateStress(
             args_in = args
         end
 
-        # Define strainrate 
+        # Define strainrate
         Eps_II =
             exp10.(
                 range(
@@ -162,7 +163,7 @@ function PlotStrainrateStress(
     return fig, ax, Eps_II, Tau_II_MPa
 end
 
-# Gelper function that simplifies customising the plots 
+# Gelper function that simplifies customising the plots
 function ObtainPlotArgs(i, p, args_in, linewidth, linestyle, color, label_in)
     if isa(linewidth, Tuple)
         linewidth_in = linewidth[i]
@@ -184,14 +185,14 @@ function ObtainPlotArgs(i, p, args_in, linewidth, linestyle, color, label_in)
 
     # Create a label name from the input parameters
     if isa(p, Tuple)
-        # Combined creep law 
+        # Combined creep law
         Name = ""
         Type = ""
         label = "$Type: $Name $args_in"
     else
         #if haskey(p,"Name")
         #    Name = String(collect(p.Name))
-        #    # determine type of creeplaw 
+        #    # determine type of creeplaw
         #    Type = "$(typeof(p))"           # full name of type
         #else
             Name = "";
@@ -203,7 +204,7 @@ function ObtainPlotArgs(i, p, args_in, linewidth, linestyle, color, label_in)
         label = "$Type: $Name $args_in"
     end
 
-    # We can manually overrule the auto-generated label 
+    # We can manually overrule the auto-generated label
     if !isnothing(label_in)
         if isa(label_in, Tuple)
             label = label_in[i]
@@ -284,12 +285,12 @@ function PlotStressStrainrate(
             args_in = args
         end
 
-        # Define strainrate 
+        # Define strainrate
         Tau_II_MPa = range(ustrip(Stress[1]); stop=ustrip(Stress[2]), length=101)
         Tau_II = Tau_II_MPa .* 1e6
         Eps_II = zeros(size(Tau_II))
 
-        
+
         # Compute stress
         #compute_εII!(Eps_II, p, Tau_II, args_in)       # Compute strainrate
         for j in eachindex(Tau_II)
@@ -320,8 +321,8 @@ function PlotStressStrainrate(
 end
 
 """
-    fig, ax, εII, η = PlotStrainrateViscosity(x; args=(T=1000.0, P=0.0, d=1e-3, f=1.0), Strainrate=(1e-18,1e-12),    
-                                linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="", 
+    fig, ax, εII, η = PlotStrainrateViscosity(x; args=(T=1000.0, P=0.0, d=1e-3, f=1.0), Strainrate=(1e-18,1e-12),
+                                linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="",
                                 fig=nothing, filename=nothing, res=(1200, 1200), legendsize=15, labelsize=35)
 
 Same as `PlotStrainrateStress` but versus viscosity instead of stress.
@@ -375,7 +376,7 @@ function PlotStrainrateViscosity(
             args_in = args
         end
 
-        # Define strainrate 
+        # Define strainrate
         Eps_II =
             exp10.(
                 range(
@@ -423,8 +424,8 @@ function PlotStrainrateViscosity(
 end
 
 """
-    fig,ax,τII,η =  PlotStressViscosity(x; args=(T=1000.0, P=0.0, d=1e-3, f=1.0), Stress=(1e0,1e8), 
-                                    linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="", 
+    fig,ax,τII,η =  PlotStressViscosity(x; args=(T=1000.0, P=0.0, d=1e-3, f=1.0), Stress=(1e0,1e8),
+                                    linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="",
                                     fig=nothing, filename=nothing, res=(1200, 1200), legendsize=15, labelsize=35)
 
 
@@ -480,7 +481,7 @@ function PlotStressViscosity(
             args_in = args
         end
 
-        # Define strainrate 
+        # Define strainrate
         Tau_II_MPa = range(ustrip(Stress[1]); stop=ustrip(Stress[2]), length=101)
         Tau_II = Tau_II_MPa .* 1e6
         Eps_II = zeros(size(Tau_II))
@@ -621,12 +622,12 @@ end
 """
     T,phi,plt = PlotMeltFraction(p::AbstractMeltingParam; T=nothing, plt=nothing, lbl=nothing)
 
-Creates a plot of temperature `T` vs. melt fraction, as specified in `p`. 
+Creates a plot of temperature `T` vs. melt fraction, as specified in `p`.
 The 1D curve can be evaluated at a specific pressure `P` which can be given as a scalar or as an array of the same size as `T`
 
 # Optional parameters
 - `T`: temperature range
-- `P`: pressure 
+- `P`: pressure
 - `plt`: a previously generated plotting object
 - `lbl`: label of the curve
 
@@ -688,7 +689,7 @@ Example
 =======
 ```julia
 julia> PD_data =  Read_LaMEM_Perple_X_Diagram("Peridotite.in")
-Perple_X/LaMEM Phase Diagram Lookup Table: 
+Perple_X/LaMEM Phase Diagram Lookup Table:
                       File    :   Peridotite.in
                       T       :   293.0 - 1573.000039
                       P       :   1.0e7 - 2.9999999944e9
@@ -820,12 +821,12 @@ end
 
 
 """
-    fig,ax,τII,η =  PlotStressTime_0D(x;    args=(T=1000.0, P=0.0, d=1e-3, f=1.0),  
-                                            εII::Union{Number, AbstractVector}, 
+    fig,ax,τII,η =  PlotStressTime_0D(x;    args=(T=1000.0, P=0.0, d=1e-3, f=1.0),
+                                            εII::Union{Number, AbstractVector},
                                             τ0=0,
                                             Time=(1e0,1e8), nt=100,
                                             t_vec=nothing,
-                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="", 
+                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="",
                                             fig=nothing, filename=nothing, res=(1200, 1200), legendsize=15, labelsize=35, position=:rt)
 
 
@@ -882,7 +883,7 @@ function PlotStressTime_0D(
             args_in = args
         end
 
-        # Compute 
+        # Compute
         t_vec, τ_vec = time_τII_0D(p, εII, args; t=Time, nt=nt, verbose=verbose)
         Tau_II_MPa = τ_vec/τ_scale;
 
@@ -908,7 +909,7 @@ function PlotStressTime_0D(
 end
 
 """
-	fig = PlotDeformationMap(v;    args=(P=0.0, d=1e-3, f=1.0),  
+	fig = PlotDeformationMap(v;    args=(P=0.0, d=1e-3, f=1.0),
                                 σ = (1e-2, 1e8),                # in MPa
                                 T = (10, 1000),                 # in C
                                 ε = (1e-22, 1e-8),              # in 1/s
@@ -948,7 +949,7 @@ julia> PlotDeformationMap(v,  strainrate=false, viscosity=true, levels=Vector(18
 """
 function PlotDeformationMap(
     v;
-    args=(P=0.0, d=1e-3, f=1.0),  
+    args=(P=0.0, d=1e-3, f=1.0),
     σ = (1e-2, 1e8),                # in MPa
     T = (10, 1000),                 # in C
     ε = (1e-22, 1e-8),                 # in 1/s
@@ -974,7 +975,7 @@ function PlotDeformationMap(
     else
         n_components = length(v)
     end
-    
+
     if strainrate
         # compute ε as a function of τ and T
 
@@ -988,11 +989,11 @@ function PlotDeformationMap(
             args_local = merge(args, (T=Tlocal,))
 
             εII[i] = compute_εII(v, τlocal, args_local)       # compute strainrate (1/s)
-            η[i]   = computeViscosity_εII(v, τlocal, args_local) 
+            η[i]   = computeViscosity_εII(v, τlocal, args_local)
 
             ε_components =  [ compute_εII(v[i], τlocal, args_local) for i=1:n_components];
-            ε_components = ε_components./sum(ε_components) 
-            mainDef[i] = argmax(ε_components)                 # index of max. strainrate 
+            ε_components = ε_components./sum(ε_components)
+            mainDef[i] = argmax(ε_components)                 # index of max. strainrate
         end
 
         log_σ = log10.(σ_vec./1e6)
@@ -1013,8 +1014,8 @@ function PlotDeformationMap(
             η[i]   = τII[i] / (2 * εlocal)
 
             τ_components =  [ compute_τII(v[i],  εlocal, args_local) for i=1:n_components];
-            τ_components = τ_components./sum(τ_components) 
-            mainDef[i] = argmin(τ_components)                 # index of max. strainrate 
+            τ_components = τ_components./sum(τ_components)
+            mainDef[i] = argmin(τ_components)                 # index of max. strainrate
         end
         log_ε = log10.(ε_vec)
     end
@@ -1041,7 +1042,7 @@ function PlotDeformationMap(
         data = log10.(η)
     end
 
-    if rotate_axes 
+    if rotate_axes
         x,y = y,x
         xlabel,ylabel = ylabel,xlabel
         data,mainDef = data', mainDef'
@@ -1049,7 +1050,7 @@ function PlotDeformationMap(
 
     # Plotting with Makie
     fig = Figure(; fontsize=fontsize, resolution=res)
-    
+
     ax = Axis(
         fig[1,1],
         title="Deformation mechanism map",
@@ -1060,7 +1061,7 @@ function PlotDeformationMap(
     contour!(ax,x,y,data, color=:black, levels=levels)
 
     if boundaries
-        # plot boundaries between deformation regimes    
+        # plot boundaries between deformation regimes
         contour!(ax,x,y,mainDef, color=:red, linewidth=2, linestyle=:solid, levels=n_components-1)
     end
 
@@ -1076,12 +1077,12 @@ function PlotDeformationMap(
 end
 
 """
-    fig, ax1, ax2, P_MPa, Tau_II_MPa, t_vec =  PlotPressureStressTime_0D(x;    args=(T=1000.0, P=0.0, d=1e-3, f=1.0),  εII::Union{Number, AbstractVector}, εvol::Union{Number, AbstractVector}, 
+    fig, ax1, ax2, P_MPa, Tau_II_MPa, t_vec =  PlotPressureStressTime_0D(x;    args=(T=1000.0, P=0.0, d=1e-3, f=1.0),  εII::Union{Number, AbstractVector}, εvol::Union{Number, AbstractVector},
                                             τ0=0,
                                             P0=0,
                                             Time=(1e0,1e8), nt=100,
                                             t_vec=nothing,
-                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="", 
+                                            linestyle=:solid, linewidth=1, color=nothing, label=nothing, title="",
                                             fig=nothing, filename=nothing, res=(1200, 1200), legendsize=15, labelsize=35)
 
 
@@ -1125,7 +1126,7 @@ function PlotPressureStressTime_0D(
     else
         xlabel_str = "Time [Myrs]";
     end
-    
+
     ax1 = Axis(
         fig[1, 1];
         ylabel=ylabel_str,
@@ -1165,26 +1166,26 @@ function PlotPressureStressTime_0D(
             args_in = args
         end
 
-        # Compute 
+        # Compute
         t_vec, p_vec, τ_vec = time_p_τII_0D(p, εII, εvol, args; t=Time, nt=nt, verbose=verbose)
         Tau_II_MPa = τ_vec/τ_scale;
         P_MPa      = p_vec/τ_scale;
-        
+
         # Retrieve plot arguments (label, color etc.)
         plot_args = ObtainPlotArgs(i, p, args_in, linewidth, linestyle, color, label)
 
         # Create plot:
-        li_1 = lines!(ax1, t_vec/t_scale, Tau_II_MPa)    
-        li_2 = lines!(ax2, t_vec/t_scale, P_MPa)    
-        
+        li_1 = lines!(ax1, t_vec/t_scale, Tau_II_MPa)
+        li_2 = lines!(ax2, t_vec/t_scale, P_MPa)
+
         # Customize plot:
         customize_plot!(li_1, plot_args)
         customize_plot!(li_2, plot_args)
-        
+
     end
 
     axislegend(ax2; labelsize=legendsize)
-    
+
     if !isnothing(filename)
         save(filename, fig)
     else

--- a/src/Plotting/StrengthEnvelope.jl
+++ b/src/Plotting/StrengthEnvelope.jl
@@ -1,7 +1,12 @@
-using Parameters
-using .GLMakie
+# This function is implemented in this file
+import GeoParams: StrengthEnvelopePlot
 
-export StrengthEnvelopePlot
+# Make all `export`ed names from GeoParams.jl available
+using GeoParams
+# We also need the following un-`export`ed names
+using GeoParams: AbstractTempStruct
+
+using Parameters
 
 function StrengthEnvelopePlot(MatParam::NTuple{N, AbstractMaterialParamsStruct}, Thickness::Vector{U}; TempType::AbstractTempStruct=LinTemp(), nz::Int64=101) where {N, U}
 
@@ -64,7 +69,7 @@ function StrengthEnvelopePlot(MatParam::NTuple{N, AbstractMaterialParamsStruct},
 
     # create listener to sliders
     T_slider     = lsgrid.sliders[1].value
-    
+
     exp_slider   = lsgrid.sliders[2].value
     ε            = @lift(10^$exp_slider/s)
 
@@ -82,7 +87,7 @@ function StrengthEnvelopePlot(MatParam::NTuple{N, AbstractMaterialParamsStruct},
 
     # get results from computational routine
     res          = @lift(StrengthEnvelopeComp(MatParam, Thickness, $Temp, $ε, nz))
-    
+
     # extract components for plotting
     z_plot       = @lift(extractFromResult($res, 1, nz))
     τ_plot       = @lift(extractFromResult($res, 2, nz))


### PR DESCRIPTION
I updated the optional plotting code from Requires.jl to package extensions for newer Julia versions. I kept backwards compatibility by still using Requires.jl for old Julia versions. This cuts the loading time `using GLMakie, GeoParams` for me by something between 0.5 and 1.5 seconds. However, there is still a lot of recompilation left, so this should be investigated in the future.

Caveats:
- I did not test this - except checking that `using GLMakie, GeoParams` works on Julia v1.8 and v1.9. I do not know whether the plotting routines are tested in CI (see #103) but I will assume that everything is fine if CI passes.
- There are still some remnants of a previos version using Plots.jl (see #104). I did not update them to GLMakie.jl.