### PR TITLE
Speeding up strain rate and deviatoric stress kernels

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -7,7 +7,7 @@ using Base: Float64
 using Parameters, LaTeXStrings, Unitful
 using ..Units
 using GeoParams: AbstractMaterialParam, AbstractConstitutiveLaw, AbstractComposite
-import GeoParams: param_info, fastpow, nphase, ntuple_idx, @print
+import GeoParams: param_info, fastpow, pow_check, nphase, ntuple_idx, @print
 import GeoParams: second_invariant, second_invariant_staggered
 using BibTeX
 using ..MaterialParameters: MaterialParamsInfo

--- a/src/CreepLaw/DiffusionCreep.jl
+++ b/src/CreepLaw/DiffusionCreep.jl
@@ -181,10 +181,14 @@ Returns diffusion creep strainrate as a function of 2nd invariant of the stress 
     @unpack_val n, r, p, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
+    f_r = pow_check(f, r)
+    d_p = pow_check(d, p)
+    TauII_FT_n = pow_check(FT * TauII, n)
+
     return A *
-           fastpow(TauII * FT, n) *
-           fastpow(f, r) *
-           fastpow(d, p) *
+           TauII_FT_n *
+           f_r *
+           d_p *
            exp(-(E + P * V) / (R * T)) / FE
 end
 
@@ -194,7 +198,11 @@ end
     @unpack_units n, r, p, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
-    ε = A * fastpow(TauII * FT, n) * fastpow(f, r) * fastpow(d, p) * exp(-(E + P * V) / (R * T)) / FE
+    f_r = pow_check(f, r)
+    d_p = pow_check(d, p)
+    TauII_FT_n = pow_check(FT * TauII, n)
+
+    ε = A * TauII_FT_n * f_r * d_p * exp(-(E + P * V) / (R * T)) / FE
 
     return ε
 end
@@ -231,16 +239,19 @@ returns the derivative of strainrate versus stress
 )
     @unpack_val n, r, p, A, E, V, R = a
     FT, FE = a.FT, a.FE
+    
+    f_r = pow_check(f, r)
+    d_p = pow_check(d, p)
+    TauII_FT_n = pow_check(FT * TauII, -1 + n)
 
-    return fastpow(FT * TauII, -1 + n) *
-           fastpow(f, r) *
-           fastpow(d, p) *
+    return TauII_FT_n *
+           f_r *
+           d_p *
            A *
            FT *
            exp((-E - P * V) / (R * T)) *
            inv(FE)
 end
-
 
 @inline function dεII_dτII(
     a::DiffusionCreep, TauII::Quantity; T=1K, P=0Pa, f=1NoUnits, d=1m, kwargs...
@@ -248,16 +259,17 @@ end
     @unpack_units n, r, p, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
+    f_r = pow_check(f, r)
+    d_p = pow_check(d, p)
+
     return FT  *
-           fastpow(f, r) *
-           fastpow(d, p) *
+           f_r *
+           d_p *
            A *
            FT *
            exp((-E - P * V) / (R * T)) *
            inv(FE)
 end
-
-
 
 """
     computeCreepLaw_TauII(EpsII::_T, a::DiffusionCreep; T::_T, P=zero(_T), f=one(_T), d=one(_T), kwargs...)
@@ -272,11 +284,16 @@ Returns diffusion creep stress as a function of 2nd invariant of the strain rate
     
     n_inv = inv(n)
     
+    A_n = pow_check(A, -n_inv)
+    EpsII_FE_n = pow_check(EpsII * FE, n_inv)
+    f_r = pow_check(f, -r * n_inv)
+    d_p = pow_check(d, -p * n_inv)
+
     τ =
-        fastpow(A, -n_inv) *
-        fastpow(EpsII * FE, n_inv) *
-        fastpow(f, -r * n_inv) *
-        fastpow(d, -p * n_inv) *
+        A_n *
+        EpsII_FE_n *
+        f_r*
+        d_p*
         exp((E + P * V) / (n * R * T)) / FT
 
     return τ
@@ -290,11 +307,15 @@ end
 
     n_inv = inv(n)
     
+    A_n = pow_check(A, -n_inv)
+    f_r = pow_check(f, -r * n_inv)
+    d_p = pow_check(d, -p * n_inv)
+
     τ =
-        fastpow(A, -n_inv) *
-        fastpow(EpsII * FE, 1) *
-        fastpow(f, -r * n_inv) *
-        fastpow(d, -p * n_inv) *
+        A_n *
+        EpsII * FE *
+        f_r *
+        d_p *
         exp((E + P * V) / (n * R * T)) / FT
 
     return τ
@@ -325,15 +346,20 @@ end
 
     n_inv = inv(n)
     
+    A_n = pow_check(A, -n_inv)
+    EpsII_FE_n = pow_check(EpsII * FE, n_inv-1)
+    f_r = pow_check(f, -r * n_inv)
+    d_p = pow_check(d, -p * n_inv)
+
     # computed symbolically:
     return (
         FE *
-        fastpow(A, -n_inv) *
-        fastpow(d, -p * n_inv) *
-        fastpow(f, -r * n_inv) *
-        fastpow(EpsII * FE, n_inv - 1) *
+        A_n *
+        d_p *
+        f_r *
+        EpsII_FE_n *
         exp((E + P * V) / (n * R * T ))
-    ) / (FT )
+    ) / FT
 end
 
 @inline function dτII_dεII(
@@ -342,15 +368,17 @@ end
     @unpack_units r, p, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
+    f_r = pow_check(f, -r)
+    d_p = pow_check(d, -p)
+
     # computed symbolically:
     return (
         FE *
         inv(A) *
-        fastpow(d, -p ) *
-        fastpow(f, -r ) *
-        fastpow(EpsII * FE, 0) *
+        d_p *
+        f_r *
         exp((E + P * V) / (R * T ))
-    ) / (FT )
+    ) / FT
 end
 
 # Print info 

--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -160,7 +160,10 @@ end
     @unpack_val n, r, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
-    ε = A * fastpow(TauII * FT, n) * fastpow(f, r) * exp(-(E + P * V) / (R * T)) / FE
+    f_r = pow_check(f, r)
+    TauII_FT_n = pow_check(FT * TauII, n)
+
+    ε = A * TauII_FT_n * f_r * exp(-(E + P * V) / (R * T)) / FE
     return ε
 end
 
@@ -170,7 +173,10 @@ end
     @unpack_units n, r, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
-    ε = A * fastpow(TauII * FT, n) * fastpow(f, r) * exp(-(E + P * V) / (R * T)) / FE
+    f_r = pow_check(f, r)
+    TauII_FT_n = pow_check(FT * TauII, n)
+
+    ε = A * TauII_FT_n * f_r * exp(-(E + P * V) / (R * T)) / FE
 
     return ε
 end
@@ -197,8 +203,11 @@ end
     @unpack_val n, r, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
-    return fastpow(FT * TauII, -1 + n) *
-           fastpow(f, r) *
+    f_r = pow_check(f, r)
+    FT_TauII_n = pow_check(FT * TauII, -1 + n)
+
+    return FT_TauII_n *
+           f_r *
            A *
            FT *
            n *
@@ -211,9 +220,12 @@ end
 )
     @unpack_units n, r, A, E, V, R = a
     FT, FE = a.FT, a.FE
+    
+    f_r = pow_check(f, r)
+    FT_TauII_n = pow_check(FT * TauII, -1 + n)
 
-    return fastpow(FT * TauII, -1 + n) *
-           fastpow(f, r)*
+    return FT_TauII_n *
+           f_r *
            A *
            FT *
            n *
@@ -243,9 +255,13 @@ Computes the stress for a Dislocation creep law given a certain strain rate
     FT, FE = a.FT, a.FE
     _n = inv(n)
     
-    return fastpow(A, -_n) *
-           fastpow(EpsII * FE, _n) *
-           fastpow(f, -r * _n) *
+    A_n = pow_check(A, -_n)
+    f_r = pow_check(f, -r * _n)
+    EpsII_FE_n = pow_check(EpsII * FE, _n)
+
+    return A_n *
+           EpsII_FE_n *
+           f_r *
            exp((E + P * V) / (n * R * T)) / FT
 end
 
@@ -256,9 +272,13 @@ end
     FT, FE = a.FT, a.FE
     _n = inv(n)
 
-    return fastpow(A, -_n) *
-           fastpow(EpsII * FE, _n) *
-           fastpow(f, -r * _n) *
+    A_n = pow_check(A, -_n)
+    f_r = pow_check(f, -r * _n)
+    EpsII_FE_n = pow_check(EpsII * FE, _n)
+
+    return A_n*
+           f_r*
+           EpsII_FE_n*
            exp((E + P * V) / (n * R * T)) / FT
 end
 
@@ -293,11 +313,15 @@ end
     FT, FE = a.FT, a.FE
     _n = inv(n)
 
+    A_n = pow_check(A, -_n)
+    f_r = pow_check(f, -r * _n)
+    EpsII_FE_n = pow_check(EpsII * FE, _n-1)
+
     return (
         FE *
-        fastpow(A, - _n) *
-        fastpow(f, -r * _n) *
-        fastpow(EpsII * FE, _n - 1) *
+        A_n *
+        f_r *
+        EpsII_FE_n *
         exp((E + P * V) / (R * T * n))
     ) / (FT * n)
 end
@@ -308,11 +332,15 @@ end
     @unpack_units n, r, A, E, V, R = a
     FT, FE = a.FT, a.FE
 
+    A_n = pow_check(A, -_n)
+    f_r = pow_check(f, -r * _n)
+    EpsII_FE_n = pow_check(EpsII * FE, _n-1)
+
     return (
         FE *
-        fastpow(A, - _n) *
-        fastpow(f, -r * _n) *
-        fastpow(EpsII * FE, _n - 1) *
+        A_n *
+        f_r *
+        EpsII_FE_n *
         exp((E + P * V) / (R * T * n))
     ) / (FT * n)
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -43,6 +43,16 @@ end
     return x^n
 end
 
+@inline function pow_check(x::T, n) where T
+    if isone(x) || isone(n)
+        x
+    elseif iszero(n)
+        one(T)
+    else
+        fastpow(x, n)
+    end
+end
+
 # Tuple iterators
 @generated function nreduce(f::F, v::NTuple{N,Any}) where {N,F}
     Base.@_inline_meta


### PR DESCRIPTION
Powers with floating point exponents are quite slow, and this is where mos of the time is spent when computing the stress rate or deviatoric stress of creep laws. However, in many cases the exponentials in these equations are just `x^0`, `x^1` or `1^n`, where there is not really a need to compute the power. Addresses #109 

This PR adds a check to see whether any of these cases occurs, by introducing:
```julia
@inline function pow_check(x::T, n) where T
    if isone(x) || isone(n)
        x
    elseif iszero(n)
        one(T)
    else
        fastpow(x, n)
    end
end
```
in all the `compute_εII` and `compute_τII` methods. 

This has a non-significant speed up when e.g. computing the viscosity:

```julia
εII = 1e-15
τII = 1e6
P, T = 1e9, 1e3;
args = (; P = P, T = T);

# create rheology struct
diff     = DiffusionCreep()
disl     = DislocationCreep()
rheology = SetMaterialParams(;
    CompositeRheology = CompositeRheology((diff, disl)),
)
```

This branch:
```julia-repl
In [31]: @btime compute_viscosity_εII($(rheology, τII, args)...)
  34.542 ns (0 allocations: 0 bytes)
0.4345077461371434
In [32]: @btime compute_viscosity_τII($(rheology, τII, args)...)
  20.240 ns (0 allocations: 0 bytes)
0.4345077461371434
```

`#main` branch:
```julia-repl
In [51]: @btime compute_viscosity_εII($(rheology, τII, args)...)
  50.557 ns (0 allocations: 0 bytes)
0.4345077461371434

In [52]: @btime compute_viscosity_τII($(rheology, τII, args)...)
  43.145 ns (0 allocations: 0 bytes)
0.4345077461371434
```

This could be potentially improved by moving some of these checks to compile time, but this means wraping the exponentials in the creep laws objects in `Val`s:
```julia
@inline pow_check2(::T, ::Val{0.0}) where T = one(T)
@inline pow_check2(::T, ::Val{0}) where T = one(T)
@inline pow_check2(x, ::Val{1.0}) = x
@inline pow_check2(x, ::Val{1}) = x
@inline pow_check2(x, ::Val{N}) where N =  pow_check2(x, N)

@inline function pow_check2(x::T, n) where T
    if isone(x)
        x
    else
        fastpow(x, n)
    end
end
```

```julia-repl
In [33]: V0 = Val(0.0)
Val{0.0}()

In [34]: @btime pow_check($(1.5, 0.0)...)
  6.500 ns (0 allocations: 0 bytes)
1.0

In [35]: @btime pow_check2($(1.5, V0)...)
  1.600 ns (0 allocations: 0 bytes)
1.0

In [36]: V1 = Val(1.0)
Val{1.0}()

In [37]: @btime pow_check($(1.5, 1.0)...)
  6.400 ns (0 allocations: 0 bytes)
1.5

In [38]: @btime pow_check2($(1.5, V1)...)
  2.700 ns (0 allocations: 0 bytes)
1.5

In [39]: @btime pow_check($(1.5, 2.3)...)
  14.515 ns (0 allocations: 0 bytes)
2.5410306047779248

In [40]: @btime pow_check2($(1.5, Val(2.3))...)
  12.800 ns (0 allocations: 0 bytes)
2.5410306047779248
```