### PR TITLE
Non-dimensionalization of pre-defined power laws

### DIFF
--- a/src/CreepLaw/Data/DiffusionCreep.jl
+++ b/src/CreepLaw/Data/DiffusionCreep.jl
@@ -7,6 +7,10 @@ This is a dictionary with pre-defined creep laws
 """
 SetDiffusionCreep(name::String; kwargs...) = Transform_DiffusionCreep(name; kwargs)
 
+function SetDiffusionCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+    return nondimensionalize(Transform_DiffusionCreep(name; kwargs), CharDim)
+end
+
 # predefined diffusion creep laws are to be added in the dictionary as it is done for dislocation creep laws (see 'DislocationCreep.jl')!
 const DiffusionCreep_info = Dict(
     [

--- a/src/CreepLaw/Data/DislocationCreep.jl
+++ b/src/CreepLaw/Data/DislocationCreep.jl
@@ -7,6 +7,10 @@ Sets predefined dislocation creep data from a dictionary
 """
 SetDislocationCreep(name::String; kwargs...) = Transform_DislocationCreep(name; kwargs)
 
+function SetDislocationCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+    return nondimensionalize(Transform_DislocationCreep(name; kwargs), CharDim)
+end
+
 const DislocationCreep_info = Dict(
     [
 

--- a/src/CreepLaw/Data/GrainBoundarySliding.jl
+++ b/src/CreepLaw/Data/GrainBoundarySliding.jl
@@ -9,6 +9,10 @@ function SetGrainBoundarySliding(name::String; kwargs...)
     return Transform_GrainBoundarySliding(name; kwargs)
 end
 
+function SetGrainBoundarySliding(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+    nondimensionalize(Transform_GrainBoundarySliding(name; kwargs), CharDim)
+end
+
 # predefined grain boundary sliding laws are to be added in the dictionary as it is done for dislocation creep laws (see 'DislocationCreep.jl')!
 const GrainBoundarySliding_info = Dict(
     [

--- a/src/CreepLaw/Data/NonLinearPeierlsCreep.jl
+++ b/src/CreepLaw/Data/NonLinearPeierlsCreep.jl
@@ -9,6 +9,10 @@ function SetNonLinearPeierlsCreep(name::String; kwargs...)
     return Transform_NonLinearPeierlsCreep(name; kwargs)
 end
 
+function SetNonLinearPeierlsCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+    return nondimensionalize(Transform_NonLinearPeierlsCreep(name; kwargs), CharDim)
+end
+
 # predefined peierls creep laws are to be added in the dictionary as it is done for dislocation creep laws (see 'DislocationCreep.jl')!
 const NonLinearPeierlsCreep_info = Dict(
     [

--- a/src/CreepLaw/Data/PeierlsCreep.jl
+++ b/src/CreepLaw/Data/PeierlsCreep.jl
@@ -7,6 +7,10 @@ This is a dictionary with pre-defined creep laws
 """
 SetPeierlsCreep(name::String; kwargs...) = Transform_PeierlsCreep(name; kwargs)
 
+function SetPeierlsCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+    return nondimensionalize(Transform_PeierlsCreep(name; kwargs), CharDim)
+end
+
 # predefined peierls creep laws are to be added in the dictionary as it is done for dislocation creep laws (see 'DislocationCreep.jl')!
 const PeierlsCreep_info = Dict(
     [

--- a/test/test_DiffusionCreep.jl
+++ b/test/test_DiffusionCreep.jl
@@ -182,9 +182,10 @@ using GeoParams
     CharDim = GEO_units()
     creeplaw_list = DiffusionCreep_info       # all creeplaws in database
     for (key, val) in creeplaw_list
-        p     = SetDiffusionCreep(key)        # original creep law
-        p_nd  = nondimensionalize(p,CharDim)    # non-dimensionalized
-        p_dim = dimensionalize(p,CharDim)       # dimensionalized
+        p     = SetDiffusionCreep(key)                # original creep law
+        p_nd  = nondimensionalize(p,CharDim)          # non-dimensionalized
+        @test p_nd == SetDiffusionCreep(key, CharDim) # check that the non-dimensionalized version is the same as the original
+        p_dim = dimensionalize(p,CharDim)             # dimensionalized
 
         # Check that values are the same after non-dimensionalisation & dimensionalisation
         for field in fieldnames(typeof(p_dim))

--- a/test/test_GrainBoundarySliding.jl
+++ b/test/test_GrainBoundarySliding.jl
@@ -76,11 +76,12 @@ using GeoParams
 
     # Do some basic checks on all creeplaws in the DB
     CharDim = GEO_units()
-    creeplaw_list = GrainBoundarySliding_info       # all creeplaws in database
+    creeplaw_list = GrainBoundarySliding_info               # all creeplaws in database
     for (key, val) in creeplaw_list
-        p     = SetGrainBoundarySliding(key)        # original creep law
-        p_nd  = nondimensionalize(p,CharDim)    # non-dimensionalized
-        p_dim = dimensionalize(p,CharDim)       # dimensionalized
+        p     = SetGrainBoundarySliding(key)                # original creep law
+        p_nd  = nondimensionalize(p,CharDim)                # non-dimensionalized
+        @test p_nd == SetGrainBoundarySliding(key, CharDim) # check that the non-dimensionalized version is the same as the original
+        p_dim = dimensionalize(p,CharDim)                   # dimensionalized
 
         # Check that values are the same after non-dimensionalisation & dimensionalisation
         for field in fieldnames(typeof(p_dim))

--- a/test/test_NonLinearPeierlsCreep.jl
+++ b/test/test_NonLinearPeierlsCreep.jl
@@ -69,9 +69,10 @@ using GeoParams
     CharDim = GEO_units()
     creeplaw_list = NonLinearPeierlsCreep_info       # all creeplaws in database
     for (key, val) in creeplaw_list
-        p     = SetNonLinearPeierlsCreep(key)        # original creep law
-        p_nd  = nondimensionalize(p,CharDim)    # non-dimensionalized
-        p_dim = dimensionalize(p,CharDim)       # dimensionalized
+        p     = SetNonLinearPeierlsCreep(key)                # original creep law
+        p_nd  = nondimensionalize(p,CharDim)                 # non-dimensionalized
+        @test p_nd == SetNonLinearPeierlsCreep(key, CharDim) # check that the non-dimensionalized version is the same as the original
+        p_dim = dimensionalize(p,CharDim)                    # dimensionalized
 
         # Check that values are the same after non-dimensionalisation & dimensionalisation
         for field in fieldnames(typeof(p_dim))

--- a/test/test_PeierlsCreep.jl
+++ b/test/test_PeierlsCreep.jl
@@ -85,9 +85,10 @@ using GeoParams
     CharDim = GEO_units()
     creeplaw_list = PeierlsCreep_info       # all creeplaws in database
     for (key, val) in creeplaw_list
-        p     = SetPeierlsCreep(key)        # original creep law
-        p_nd  = nondimensionalize(p,CharDim)    # non-dimensionalized
-        p_dim = dimensionalize(p,CharDim)       # dimensionalized
+        p     = SetPeierlsCreep(key)                # original creep law
+        p_nd  = nondimensionalize(p,CharDim)        # non-dimensionalized
+        @test p_nd == SetPeierlsCreep(key, CharDim) # check that the non-dimensionalized version is the same as the original
+        p_dim = dimensionalize(p,CharDim)           # dimensionalized
 
         # Check that values are the same after non-dimensionalisation & dimensionalisation
         for field in fieldnames(typeof(p_dim))

--- a/test/test_Viscosity.jl
+++ b/test/test_Viscosity.jl
@@ -16,7 +16,7 @@ using Test, GeoParams
         CompositeRheology = CompositeRheology((creep, el)),
     )
 
-    @test η0 == compute_viscosity_εII(rheology, τII, args) == compute_viscosity_τII(rheology, τII, args)
+    @test η0 == compute_viscosity_εII(rheology, εII, args) == compute_viscosity_τII(rheology, τII, args)
     @test 1(1/η0 + 1/el.G.val/dt) == compute_elastoviscosity_εII(rheology, εII, args) == compute_elastoviscosity_τII(rheology, τII, args)
 
     # Slightly more complex example ----------------------


### PR DESCRIPTION
This PR adds an option to directly non-dimensionalize power laws dfined in the database. It's enough to pass the characteristic lenghts when instantiating the rheology struct.

```julia
CharDims = GEO_units(; viscosity=1e19, length=1000km)
SetDiffusionCreep("Dry Anorthite | Rybacki et al. (2006)", CharDims)
```
