### PR TITLE
Allow GeoUnits {SI} when non-dimensionalizing predifned rheology

### DIFF
--- a/src/CreepLaw/Data/DiffusionCreep.jl
+++ b/src/CreepLaw/Data/DiffusionCreep.jl
@@ -7,7 +7,7 @@ This is a dictionary with pre-defined creep laws
 """
 SetDiffusionCreep(name::String; kwargs...) = Transform_DiffusionCreep(name; kwargs)
 
-function SetDiffusionCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+function SetDiffusionCreep(name::String, CharDim::GeoUnits{T}; kwargs...) where T<:Union{GEO, SI}
     return nondimensionalize(Transform_DiffusionCreep(name; kwargs), CharDim)
 end
 

--- a/src/CreepLaw/Data/DislocationCreep.jl
+++ b/src/CreepLaw/Data/DislocationCreep.jl
@@ -7,7 +7,7 @@ Sets predefined dislocation creep data from a dictionary
 """
 SetDislocationCreep(name::String; kwargs...) = Transform_DislocationCreep(name; kwargs)
 
-function SetDislocationCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+function SetDislocationCreep(name::String, CharDim::GeoUnits{T}; kwargs...) where T<:Union{GEO, SI}
     return nondimensionalize(Transform_DislocationCreep(name; kwargs), CharDim)
 end
 

--- a/src/CreepLaw/Data/GrainBoundarySliding.jl
+++ b/src/CreepLaw/Data/GrainBoundarySliding.jl
@@ -9,7 +9,7 @@ function SetGrainBoundarySliding(name::String; kwargs...)
     return Transform_GrainBoundarySliding(name; kwargs)
 end
 
-function SetGrainBoundarySliding(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+function SetGrainBoundarySliding(name::String, CharDim::GeoUnits{T}; kwargs...)  where T<:Union{GEO, SI}
     nondimensionalize(Transform_GrainBoundarySliding(name; kwargs), CharDim)
 end
 

--- a/src/CreepLaw/Data/NonLinearPeierlsCreep.jl
+++ b/src/CreepLaw/Data/NonLinearPeierlsCreep.jl
@@ -9,7 +9,7 @@ function SetNonLinearPeierlsCreep(name::String; kwargs...)
     return Transform_NonLinearPeierlsCreep(name; kwargs)
 end
 
-function SetNonLinearPeierlsCreep(name::String, CharDim::GeoUnits{GEO}; kwargs...) 
+function SetNonLinearPeierlsCreep(name::String, CharDim::GeoUnits{T}; kwargs...)  where T<:Union{GEO, SI}
     return nondimensionalize(Transform_NonLinearPeierlsCreep(name; kwargs), CharDim)
 end
 


### PR DESCRIPTION
Relaxes the type of the characteristic length object to be parameterized as `GeoUnits{GEO}` as well as `GeoUnits{SI}`.