### PR TITLE
Fix allocations from non/dimensionalizing MatParamStructs

### DIFF
--- a/src/Units.jl
+++ b/src/Units.jl
@@ -659,8 +659,8 @@ nondimensionalizes all fields within the Material Parameters structure that cont
     N = length(params)
     quote
         Base.@_inline_meta
-        Base.@nexprs $N i -> x_i = begin
-            param = $(params)[4]
+        Base.@nexprs $N i -> phase_mat = begin
+            param = $(params)[i]
             field = getfield(phase_mat, param)
             nondimensionalize_MatParam(field, phase_mat, param, g)
         end 
@@ -813,8 +813,8 @@ Dimensionalizes all fields within the Material Parameters structure that contain
     N = length(params)
     quote
         Base.@_inline_meta
-        Base.@nexprs $N i -> x_i = begin
-            param = $(params)[4]
+        Base.@nexprs $N i -> phase_mat = begin
+            param = $(params)[i]
             field = getfield(phase_mat, param)
             dimensionalize_MatParam(field, phase_mat, param, g)
         end 

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -673,6 +673,7 @@ end
 @inline nondimensionalize_MatParam(::Any, phase_mat, ::Vararg{Any, N}) where N = phase_mat
 
 @inline _nondimensionalize_MatParam(field::AbstractMaterialParam, g) = nondimensionalize(field, g)
+@inline _nondimensionalize_MatParam(field::AbstractPhaseDiagramsStruct, g) =  PerpleX_LaMEM_Diagram(field.Name; CharDim=g)
 @inline _nondimensionalize_MatParam(field, g) = field
 
 @inline function nondimensionalize_MatParam(field::NTuple{N, AbstractMaterialParam}, phase_mat, param, g) where N
@@ -680,12 +681,6 @@ end
         Base.@_inline_meta
         _nondimensionalize_MatParam(field[i], g)
     end
-    return set(phase_mat, Setfield.PropertyLens{param}(), field_new)
-end
-
-@inline function nondimensionalize_MatParam(field::AbstractPhaseDiagramsStruct, phase_mat, param, g)
-    temp = PerpleX_LaMEM_Diagram(field.Name; CharDim=g)
-    field_new = (temp,)
     return set(phase_mat, Setfield.PropertyLens{param}(), field_new)
 end
 

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -1,7 +1,6 @@
 # Tests the GeoUnits
 using Test
 using GeoParams
-#using Parameters
 
 @testset "Units" begin
 
@@ -296,7 +295,7 @@ using GeoParams
         ρ::GeoUnit
     end
 
-    # add type info in name, but no default values
+    # add type info in name, but no default values (GeoUnit{T}, is still NOT concrete, dont use this definition)
     mutable struct ConDensity4{T<:AbstractFloat} <: AbstractMaterialParam  # 1 allocation
         test::String
         ρ::GeoUnit{T}
@@ -331,13 +330,13 @@ using GeoParams
         v::GeoUnit = 100 / s
     end
 
-    # This works with 1 allocation, and is the preferred way to use it within GeoParams
-    Base.@kwdef struct ConDensity9{T<:AbstractFloat} <: AbstractMaterialParam # 1 allocation
+    # No allocations (ρ and v have concrete types this time), and is the
+    # preferred way to use it within GeoParams
+    Base.@kwdef struct ConDensity9{U1,U2} <: AbstractMaterialParam # 1 allocation
         test::String = ""
-        ρ::GeoUnit{T} = 3300.1kg / m^3
-        v::GeoUnit{T} = 100.0m / s
+        ρ::U1 = 3300.1kg / m^3
+        v::U2 = 100.0m / s
     end
-    ConDensity9(a...) = ConDensity9{Float64}(a...)  # in case we do not give a type
 
     rho = ConDensity(3300.1)
     rho1 = ConDensity1("t", GeoUnit(3300.1kg / m^3), GeoUnit(100 / s))
@@ -349,11 +348,11 @@ using GeoParams
     rho7 = ConDensity7()
     rho8 = ConDensity8()
     rho9 = ConDensity9(; ρ=2800kg / m^3)
-    rho9_ND = nondimensionalize(rho9, GEO_units())
+    rho9_ND = nondimensionalize(rho9, GEO_units()) # this is type stable, unlike with the rho* variables above
 
     # test automatic nondimensionalization of a MaterialsParam struct:
     CD = GEO_units()
-    rho2_ND = nondimensionalize(rho2, CD)
+    rho2_ND = nondimensionalize(rho2, CD) # type unstable...
     @test rho2_ND.ρ ≈ 3.3000999999999995e-18
     @test rho2_ND.v ≈ 9.999999999999999e11
 
@@ -364,7 +363,7 @@ using GeoParams
     # Simple function to test speed
     function f!(r, x, y)
         for i in 1:1000
-            r += x.ρ * y          # compute
+            r += x.ρ * GeoUnit(y)          # compute
         end
         return r
     end
@@ -380,7 +379,7 @@ using GeoParams
 
     #=
     # testing speed (# of allocs)
-    r = 0.0
+    r = GeoUnit(0.0)
     @btime f!($r, $rho,  $c)    # 1 allocations
     @btime f!($r, $rho1, $c)    # 1 allocation
     @btime f!($r, $rho2, $c)    # 3001 allocations
@@ -388,9 +387,9 @@ using GeoParams
     @btime f!($r, $rho4, $c)    # 1 allocation
     @btime f!($r, $rho5, $c)    # 3001 allocation
     @btime f!($r, $rho6, $c)    # 3001 allocation (so also with keywords, it is crucial to indicate the type)
-    @btime f!($r, $rho7, $c)    # 1 allocation (shows that we need to encode the units)
+    @btime f!($r, $rho7, $c)    # 1 allocation (shows that we the variables are not of concrete types)
     @btime f!($r, $rho8, $c)    # 3001 allocation 
-    @btime f!($r, $rho9, $c)    # 1 allocation (shows that we need to encode the units)
+    @btime f!($r, $rho9, $c)    # 0 allocations
     @btime f!($r, $rho9_ND, $c) 
     =#
 


### PR DESCRIPTION
```julia
function foo()
    # This tests the MaterialParameters structure
    g = CharUnits_GEO = GEO_units(; viscosity=1e19, length=1000km)

    # Define a struct for a first phase
    x = SetMaterialParams(;
        Name="test1",
        Phase=22,
        CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e21Pa * s)),
        Gravity=ConstantGravity(; g=11.0m / s^2),
        Density=ConstantDensity(),
    )

    x_nd = nondimensionalize(x, CharUnits_GEO)

    # Define a struct for a first phase
    y = SetMaterialParams(;
        Name="test1",
        Phase=22,
        CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e21Pa * s)),
        Gravity=ConstantGravity(; g=11.0m / s^2),
        Density=ConstantDensity(),
        CharDim = CharUnits_GEO
    )

    a, b, c = 0, 0, 0
    ta, tb, tc = 0, 0, 0
    for _ in 1:1_000_000
        ta += @elapsed begin a += @allocated begin compute_density(x_nd, (;)) end end
        tb += @elapsed begin b += @allocated begin compute_density(x, (;)) end end
        tc += @elapsed begin c += @allocated begin compute_density(y, (;)) end end
    end

    println("a => $a allocated, $ta seconds")
    println("b => $b allocated, $tb seconds")
    println("c => $c allocated, $tc seconds")
end
```

This PR
```julia-repl
In [16]: foo()
a => 0 allocated, 0.0568452000006039 seconds
b => 0 allocated, 0.05718950000061417 seconds
c => 0 allocated, 0.05717680000061389 seconds
```

#main
```julia-repl
In [1]: foo()
a => 16000000 allocated, 0.08244640000127741 seconds
b => 0 allocated, 0.0606366000007116 seconds
c => 16000000 allocated, 0.08222860000127924 seconds
```

So theres a c. 40% performance improvement and no more allocations :)