### PR TITLE
[Proposal] Default rheology names to nothing

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -8,7 +8,7 @@ using Parameters, LaTeXStrings, Unitful
 using ..Units
 using GeoParams: AbstractMaterialParam, AbstractConstitutiveLaw, AbstractComposite
 import GeoParams: param_info, fastpow, pow_check, nphase, ntuple_idx, @print, @pow
-import GeoParams: second_invariant, second_invariant_staggered, value_and_partial
+import GeoParams: second_invariant, second_invariant_staggered, value_and_partial, printable_name
 using BibTeX
 using ..MaterialParameters: MaterialParamsInfo
 import Base.show

--- a/src/CreepLaw/Data/DislocationCreep.jl
+++ b/src/CreepLaw/Data/DislocationCreep.jl
@@ -187,7 +187,7 @@ function DislocationCreep_data(name::String)
         return DislocationCreep(;
             Name = "Granite | Tirel et al. (2008)",
             n = 3.2NoUnits,
-            A = 1.25e-9MPa^(-3.2) / s,
+            A = 1.25e-9MPa^(-16 // 5) / s,
             E = 123kJ / mol,
             V = 0.0m^3 / mol,
             r = 0.0NoUnits,

--- a/src/CreepLaw/DiffusionCreep.jl
+++ b/src/CreepLaw/DiffusionCreep.jl
@@ -62,7 +62,7 @@ struct DiffusionCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
     FE::T # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 
     function DiffusionCreep(;
-        Name="",
+        Name=nothing,
         n=1NoUnits,
         r=0NoUnits,
         p=-3NoUnits,
@@ -91,7 +91,7 @@ struct DiffusionCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         U4 = typeof(VU).types[2]
         U5 = typeof(RU).types[2]
         # Create struct
-        return new{T,String,U1,U2,U3,U4,U5}(
+        return new{T,typeof(Name),U1,U2,U3,U4,U5}(
             Name, nU, rU, pU, AU, EU, VU, RU, Int8(Apparatus), FT, FE
         )
     end
@@ -358,7 +358,7 @@ end
 function show(io::IO, g::DiffusionCreep)
     return print(
         io,
-        "DiffusionCreep: Name = $(String(collect(g.Name))), n=$(Value(g.n)), r=$(Value(g.r)), p=$(Value(g.p)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE)",
+        "DiffusionCreep: Name = $(printable_name(g.Name)), n=$(Value(g.n)), r=$(Value(g.r)), p=$(Value(g.p)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE)",
     )
 end
 

--- a/src/CreepLaw/DislocationCreep.jl
+++ b/src/CreepLaw/DislocationCreep.jl
@@ -55,7 +55,7 @@ struct DislocationCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
     FE::T # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 
     function DislocationCreep(;
-        Name="",
+        Name=nothing,
         n=1NoUnits,
         r=0NoUnits,
         A=1.5MPa^(-n) / s,
@@ -81,7 +81,7 @@ struct DislocationCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         U4 = typeof(VU).types[2]
         U5 = typeof(RU).types[2]
         # Create struct
-        return new{T,String,U1,U2,U3,U4,U5}(
+        return new{T,typeof(Name),U1,U2,U3,U4,U5}(
             Name, nU, rU, AU, EU, VU, RU, Int8(Apparatus), FT, FE
         )
     end
@@ -92,6 +92,11 @@ struct DislocationCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         )
     end
 end
+
+@inline str2char(str::NTuple{N, Char}) where N = str
+@inline str2char(str::String) = str2char(str, static(length(str)))
+@inline str2char(str::String, ::StaticInt{N}) where N = ntuple(i->str[i], Val(N))
+@inline str2char(::String, ::StaticInt{0}) = ()
 
 Adapt.@adapt_structure DislocationCreep
 
@@ -311,7 +316,7 @@ end
 function show(io::IO, g::DislocationCreep)
     return print(
         io,
-        "DislocationCreep: Name = $(String(collect(g.Name))), n=$(Value(g.n)), r=$(Value(g.r)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
+        "DislocationCreep: Name = $(printable_name(g.Name)), n=$(Value(g.n)), r=$(Value(g.r)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
     )
 end
 #-------------------------------------------------------------------------

--- a/src/CreepLaw/GrainBoundarySliding.jl
+++ b/src/CreepLaw/GrainBoundarySliding.jl
@@ -58,7 +58,7 @@ struct GrainBoundarySliding{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
     FE::T # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 
     function GrainBoundarySliding(;
-        Name="",
+        Name=nothing,
         n=(7//2)NoUnits,
         p=-2NoUnits,
         A=6500MPa^(-n) * s^(-1.0) * µm^(2),
@@ -85,7 +85,7 @@ struct GrainBoundarySliding{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         U4 = typeof(VU).types[2]
         U5 = typeof(RU).types[2]
         # Create struct
-        return new{T,String,U1,U2,U3,U4,U5}(
+        return new{T,typeof(Name),U1,U2,U3,U4,U5}(
             Name, nU, pU, AU, EU, VU, RU, Int8(Apparatus), FT, FE
         )
     end
@@ -335,7 +335,7 @@ end
 function show(io::IO, g::GrainBoundarySliding)
     return print(
         io,
-        "GrainBoundarySliding: Name = $(String(collect(g.Name))), n=$(Value(g.n)), p=$(Value(g.p)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE)",
+        "GrainBoundarySliding: Name = $(printable_name(g.Name)), n=$(Value(g.n)), p=$(Value(g.p)), A=$(Value(g.A)), E=$(Value(g.E)), V=$(Value(g.V)), FT=$(g.FT), FE=$(g.FE)",
     )
 end
 

--- a/src/CreepLaw/NonLinearPeierlsCreep.jl
+++ b/src/CreepLaw/NonLinearPeierlsCreep.jl
@@ -49,7 +49,7 @@ struct NonLinearPeierlsCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
     FE::T # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 
     function NonLinearPeierlsCreep(;
-        Name="",
+        Name=nothing,
         n=2NoUnits,
         q=1.0NoUnits,
         o=0.5NoUnits,
@@ -78,7 +78,7 @@ struct NonLinearPeierlsCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         U5 = typeof(RU).types[2]
 
         # Create struct
-        return new{T,String,U1,U2,U3,U4,U5}(
+        return new{T,typeof(Name),U1,U2,U3,U4,U5}(
             Name, nU, qU, oU, TauPU, AU, EU, RU, Int8(Apparatus), FT, FE
         )
     end
@@ -230,7 +230,7 @@ end
 function show(io::IO, g::NonLinearPeierlsCreep)
     return print(
         io,
-        "NonLinearPeierlsCreep: Name = $(String(collect(g.Name))), n=$(Value(g.n)), q=$(Value(g.q)), o=$(Value(g.o)), TauP=$(Value(g.TauP)), A=$(Value(g.A)), E=$(Value(g.E)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
+        "NonLinearPeierlsCreep: Name = $(printable_name(g.Name)), n=$(Value(g.n)), q=$(Value(g.q)), o=$(Value(g.o)), TauP=$(Value(g.TauP)), A=$(Value(g.A)), E=$(Value(g.E)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
     )
 end
 #-------------------------------------------------------------------------

--- a/src/CreepLaw/PeierlsCreep.jl
+++ b/src/CreepLaw/PeierlsCreep.jl
@@ -49,7 +49,7 @@ struct PeierlsCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
     FE::T # type of experimental apparatus, either AxialCompression, SimpleShear or Invariant
 
     function PeierlsCreep(;
-        Name="",
+        Name=nothing,
         n=1.0NoUnits,
         q=2.0NoUnits,
         o=1.0NoUnits,
@@ -78,7 +78,7 @@ struct PeierlsCreep{T,S,U1,U2,U3,U4,U5} <: AbstractCreepLaw{T}
         U5 = typeof(RU).types[2]
 
         # Create struct
-        return new{T,String,U1,U2,U3,U4,U5}(
+        return new{T,typeof(Name),U1,U2,U3,U4,U5}(
             Name, nU, qU, oU, TauPU, AU, EU, RU, Int8(Apparatus), FT, FE
         )
     end
@@ -256,7 +256,7 @@ end
 function show(io::IO, g::PeierlsCreep)
     return print(
         io,
-        "PeierlsCreep: Name = $(String(collect(g.Name))), n=$(Value(g.n)), q=$(Value(g.q)), o=$(Value(g.o)), TauP=$(Value(g.TauP)), A=$(Value(g.A)), E=$(Value(g.E)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
+        "PeierlsCreep: Name = $(printable_name(g.Name)), n=$(Value(g.n)), q=$(Value(g.q)), o=$(Value(g.o)), TauP=$(Value(g.TauP)), A=$(Value(g.A)), E=$(Value(g.E)), FT=$(g.FT), FE=$(g.FE), Apparatus=$(g.Apparatus)",
     )
 end
 #-------------------------------------------------------------------------

--- a/src/MaterialParameters.jl
+++ b/src/MaterialParameters.jl
@@ -11,8 +11,11 @@ using Static, Adapt
 
 import Base.show, Base.convert
 using GeoParams:
-    AbstractMaterialParam, AbstractMaterialParamsStruct, AbstractPhaseDiagramsStruct, AbstractComposite 
-
+    AbstractMaterialParam, 
+    AbstractMaterialParamsStruct, 
+    AbstractPhaseDiagramsStruct, 
+    AbstractComposite,
+    printable_name
 
 # Define an "empty" Material parameter structure
 struct No_MaterialParam{_T} <: AbstractMaterialParam end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -123,3 +123,7 @@ end
     df =  f(ForwardDiff.Dual{T}(x, one(x)), )     
     return df.value, ForwardDiff.extract_derivative(T, df) 
 end
+
+# Convert to printable name
+printable_name(str) = String(collect(str))
+printable_name(::Nothing) = "Unnamed"


### PR DESCRIPTION
I was too quick with the fix related to the rheology names in #122. 

**Problem** 
`String`s are not isbits and converting them to a isbits representation that is not an array is type unstable:

```julia
str2char(str::String) = ntuple(i->str[i], length(str))
```

```julia
In [18]: @code_warntype str2char(str)
MethodInstance for str2char(::String)
  from str2char(str::String) @ Main c:\Users\albert\Desktop\GeoParams.jl\GeoParams.jl\rot.jl:86
Arguments
  #self#::Core.Const(str2char)
  str::String
Locals
  #36::var"#36#37"{String}
Body::Tuple{Vararg{Char}}
1 ─ %1 = Main.:(var"#36#37")::Core.Const(var"#36#37")
│   %2 = Core.typeof(str)::Core.Const(String)
│   %3 = Core.apply_type(%1, %2)::Core.Const(var"#36#37"{String})
│        (#36 = %new(%3, str))
│   %5 = #36::var"#36#37"{String}
│   %6 = Main.length(str)::Int64
│   %7 = Main.ntuple(%5, %6)::Tuple{Vararg{Char}}
└──      return %7
```

**Solution for GPUs**
The only solution I could find is to use an `Array` instead of a tuple
```julia
xc = [Char(x) for x in x]
```
so that `xc_gpu = CuArray(xc)` works in CUDA kernels (same for ROCArrays).

**Proposal**
Default all the names to `Name=nothing` (including those rheologies in the databases), and let the user fill the name with the appropriate value type. And document this issue somewhere in the docs. 
