### PR TITLE
Bugfix for operations on nondimensional GeoUnits

### DIFF
--- a/src/Units.jl
+++ b/src/Units.jl
@@ -234,7 +234,7 @@ for op in (:+, :-, :*, :/)
     # Multiplying/dividing/adding/subtracting a GeoUnit with another one, returns a GeoUnit
     @eval function Base.$op(x::GeoUnit, y::GeoUnit) 
         isdimensional_new_unit = x.isdimensional*y.isdimensional
-        new_value = $(op)(UnitValue(x), UnitValue(y))
+        new_value = $(op)(upreferred.(UnitValue(x)), upreferred.(UnitValue(y)))
         if isdimensional_new_unit
             new_unit = unit(new_value)
         else

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -232,7 +232,7 @@ for op in (:+, :-, :*, :/)
     @eval Base.$op(x::Number, y::GeoUnit) = $(op)(x, y.val)
 
     # Multiplying/dividing/adding/subtracting a GeoUnit with another one, returns a GeoUnit
-    @eval function Base.$op(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2}
+    @eval function Base.$op(x::GeoUnit, y::GeoUnit) 
         isdimensional_new_unit = x.isdimensional*y.isdimensional
         new_value = $(op)(UnitValue(x), UnitValue(y))
         if isdimensional_new_unit

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -231,9 +231,21 @@ for op in (:+, :-, :*, :/)
     @eval Base.$op(x::GeoUnit, y::Number) = $(op)(x.val, y)
     @eval Base.$op(x::Number, y::GeoUnit) = $(op)(x, y.val)
 
-    # Multiplying a GeoUnit with another one, returns a GeoUnit
+    # Multiplying/dividing/adding/subtracting a GeoUnit with another one, returns a GeoUnit
     @eval function Base.$op(x::GeoUnit{T1,U1}, y::GeoUnit{T2,U2}) where {T1,T2,U1,U2}
-        return GeoUnit($(op)(UnitValue(x), UnitValue(y)))
+        isdimensional_new_unit = x.isdimensional*y.isdimensional
+        new_value = $(op)(UnitValue(x), UnitValue(y))
+        if isdimensional_new_unit
+            new_unit = unit(new_value)
+        else
+            if ($(op) == +) ||  ($(op) == -)
+                new_unit = Unit(x)
+            else
+                new_unit = $(op)(Unit(x), Unit(y))
+            end
+        end
+
+        return GeoUnit(ustrip(new_value), new_unit, isdimensional_new_unit)
     end
     @eval Base.$op(x::GeoUnit, y::Quantity) = $(op).(UnitValue(x), y)
     @eval Base.$op(x::Quantity, y::GeoUnit) = $(op).(x, UnitValue(y))

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -425,5 +425,10 @@ using GeoParams
     @test Unit(T_nd-T_nd) == K
     @test Unit(T_nd*T_nd) == K*K
     
+    T_gradients_Kkm = GeoUnit(30K)/GeoUnit(1km)
+    @test T_gradients_Kkm == GeoUnit(0.03K/m)
+    T_gradients_Ckm = (GeoUnit(30C)-GeoUnit(0C))/GeoUnit(1km)
+    @test T_gradients_Ckm == GeoUnit(0.03K/m)
+    
 
 end

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -430,5 +430,21 @@ using GeoParams
     T_gradients_Ckm = (GeoUnit(30C)-GeoUnit(0C))/GeoUnit(1km)
     @test T_gradients_Ckm == GeoUnit(0.03K/m)
     
+    # MWE of @aelligp
+    CharDim     = GEO_units(length=40km, viscosity=1e20Pa*s);
+    Depth       = GeoUnit(Array(0km:1km:10km));
+    Depth_nondim= nondimensionalize(Depth,CharDim);
+
+    Geotherm    = nondimensionalize(GeoUnit(30K/1km), CharDim)
+    Geotherm_C  = nondimensionalize(GeoUnit(30C)-GeoUnit(0C), CharDim)/nondimensionalize(GeoUnit(1km), CharDim)
+    
+    Gradient_K  = nondimensionalize(GeoUnit(273.15K),CharDim) .+ Geotherm * Depth_nondim;
+    Temp_K_dim  = dimensionalize(Gradient_K, CharDim)
+    @test all(Temp_K_dim.val .≈ (Depth.val.*30 .+ 273.15))
+
+    Gradient_C  = nondimensionalize(GeoUnit(0C),CharDim) .+ Geotherm_C * Depth_nondim;
+    Temp_C_dim  = dimensionalize(Gradient_C, CharDim)
+    @test all(Temp_C_dim.val .≈ Depth.val.*30)
+
 
 end

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -404,7 +404,7 @@ using GeoParams
     p1_nd = nondimensionalize(param1, g)
 
     # Test multiplication/division of GeoUnits in dimensional and non-dimensional from
-    # Thie addresses issue #125
+    # This addresses issue #125
     CharDim     = GEO_units(length=40km, viscosity=1e20Pa*s);
     GeoTherm    = GeoUnit(30K/1km)
     GeoTherm_nd = nondimensionalize(GeoTherm, CharDim)

--- a/test/test_GeoUnits.jl
+++ b/test/test_GeoUnits.jl
@@ -136,7 +136,7 @@ using GeoParams
     CharUnits = SI_units()
     c = nondimensionalize(a, CharUnits)
     d = nondimensionalize(b, CharUnits)
-    @test c - d == GeoUnit(1)
+    @test NumValue(c - d) == 1.0
 
     # test various calculations (using arrays with and without units)
     T_vec = (273K):(10K):(500K)        # using units
@@ -402,4 +402,28 @@ using GeoParams
     @test p_nd == (0.1, 8.0e15)
 
     p1_nd = nondimensionalize(param1, g)
+
+    # Test multiplication/division of GeoUnits in dimensional and non-dimensional from
+    # Thie addresses issue #125
+    CharDim     = GEO_units(length=40km, viscosity=1e20Pa*s);
+    GeoTherm    = GeoUnit(30K/1km)
+    GeoTherm_nd = nondimensionalize(GeoTherm, CharDim)
+    GeoTherm_dim = dimensionalize(GeoTherm_nd, CharDim)
+    @test GeoTherm == GeoTherm_dim
+    @test Unit(GeoTherm_nd) == K/km
+
+    length = GeoUnit(1km)
+    length_nd = nondimensionalize(length, CharDim)
+    T = length*GeoTherm
+    @test T == GeoUnit(30K)
+    @test Unit(T) == K
+
+
+    T_nd = length_nd*GeoTherm_nd
+    @test Unit(T) == K
+    @test Unit(T_nd+T_nd) == K
+    @test Unit(T_nd-T_nd) == K
+    @test Unit(T_nd*T_nd) == K*K
+    
+
 end


### PR DESCRIPTION
This fixes issue #125 which pointed out a bug in operations on non-dimensional GeoUnits (reported by @aelligp)

```julia
using GeoParams
CharDim    = GEO_units(length=40km, viscosity=1e20Pa*s);
T = GeoUnit(100K)
T_nd = nondimensionalize(T, CharDim)
```
Before:
```julia
julia> T_nd*T_nd
GeoUnit{nondimensional, }, 
0.006169370482479428
```

After:
```julia
julia> T_nd*T_nd
GeoUnit{nondimensional, K²·⁰}, 
0.006169370482479428
```

 