### PR TITLE
compute melt fraction with PhaseRatios

### DIFF
--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -314,6 +314,7 @@ include("./MeltFraction/MeltingParameterization.jl")
 using .MeltingParam
 export compute_meltfraction,
     compute_meltfraction!,       # calculation routines
+    compute_meltfraction_ratio,
     compute_dϕdT,
     compute_dϕdT!,
     MeltingParam_Caricchi,

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -15,6 +15,7 @@ abstract type AbstractMeltingParam{T} <: AbstractMaterialParam end
 
 export compute_meltfraction,
     compute_meltfraction!,    # calculation routines
+    compute_meltfraction_ratio,
     compute_dϕdT,             # derivative of melt fraction versus
     compute_dϕdT!,
     param_info,
@@ -709,6 +710,14 @@ compute_meltfraction(args::Vararg{Any, N}) where N = compute_param(compute_meltf
 In-place computation of melt fraction ϕ for the whole domain and all phases, in case an array with phase properties `MatParam` is provided, along with `P` and `T` arrays.
 """
 compute_meltfraction!(args::Vararg{Any, N}) where N = compute_param!(compute_meltfraction, args...)
+
+"""
+    compute_meltfraction(ϕ::AbstractArray{<:AbstractFloat}, PhaseRatios::Union{NTuple{N,T}, SVector{N,T}}, P::AbstractArray{<:AbstractFloat},T::AbstractArray{<:AbstractFloat}, MatParam::AbstractArray{<:AbstractMaterialParamsStruct})
+
+Computation of melt fraction ϕ for the whole domain and all phases, in case an array with phase properties `MatParam` is provided, along with `P` and `T` arrays.
+This assumes that the `PhaseRatio` of every point is specified as an Integer in the `PhaseRatios` array, which has one dimension more than the data arrays (and has a phase fraction between 0-1)
+"""
+compute_meltfraction_ratio(args::Vararg{Any, N}) where N = compute_param_times_frac(compute_meltfraction, args...)
 
 """
     ϕ = compute_dϕdT(Phases::AbstractArray{<:Integer}, P::AbstractArray{<:AbstractFloat},T::AbstractArray{<:AbstractFloat}, MatParam::AbstractArray{<:AbstractMaterialParamsStruct})

--- a/test/test_MeltingParam.jl
+++ b/test/test_MeltingParam.jl
@@ -250,11 +250,12 @@ using StaticArrays
     compute_dϕdT!(dϕdT, Mat_tup, Phases, args) #allocation free
     @test sum(dϕdT) / n^3 ≈ 0.0006838372430250584
 
-    # # test PhaseRatio
-    # PhaseRatio = (0.5,0.5,0.5)
-    # compute_meltfraction_ratio(PhaseRatio, Mat_tup, args) 
+    # test PhaseRatio and StaticArrays PhaseRatios as input
+    args = (P=0.0, T=1000.0 + 273.15)
+    PhaseRatio = (0.25, 0.25, 0.25, 0.25)
+    @test 0.6991003705903673 ≈ compute_meltfraction_ratio(PhaseRatio, Mat_tup, args) 
 
-    # SvPhaseRatio = SA[0.5,0.5,0.5]
-    # compute_meltfraction_ratio(SvPhaseRatio, Mat_tup, args)
+    SvPhaseRatio = SA[0.25,0.25,0.25,0.25]
+    @test 0.6991003705903673 ≈ compute_meltfraction_ratio(SvPhaseRatio, Mat_tup, args)
 
 end

--- a/test/test_MeltingParam.jl
+++ b/test/test_MeltingParam.jl
@@ -1,6 +1,7 @@
 using Test
 using LinearAlgebra
 using GeoParams
+using StaticArrays
 
 @testset "MeltingParam.jl" begin
 
@@ -248,4 +249,12 @@ using GeoParams
 
     compute_dϕdT!(dϕdT, Mat_tup, Phases, args) #allocation free
     @test sum(dϕdT) / n^3 ≈ 0.0006838372430250584
+
+    # # test PhaseRatio
+    # PhaseRatio = (0.5,0.5,0.5)
+    # compute_meltfraction_ratio(PhaseRatio, Mat_tup, args) 
+
+    # SvPhaseRatio = SA[0.5,0.5,0.5]
+    # compute_meltfraction_ratio(SvPhaseRatio, Mat_tup, args)
+
 end


### PR DESCRIPTION
This provides the same framework for melt fraction as for density and utilises `compute_param_times_frac`. 

