### PR TITLE
set default values for G and nu in SetConstantElasticity()

### DIFF
--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -48,7 +48,10 @@ ConstantElasticity(args...) = ConstantElasticity(convert.(GeoUnit, args)...)
 
 This allows setting elastic parameters by specifying 2 out of the 4 elastic parameters `G` (Elastic shear modulus), `ν` (Poisson's ratio), `E` (Young's modulus), or `Kb` (bulk modulus).
 """
-function SetConstantElasticity(; G=26e9, ν=0.4, E=nothing, Kb=nothing)
+function SetConstantElasticity(; G=nothing, ν=nothing, E=nothing, Kb=nothing)
+    if all(isnothing, (G, ν, E, Kb))
+        G, ν = 26e9Pa, 0.4
+    end
     if (!isnothing(G) && !isnothing(ν))
         Kb = 2 * G * (1 + ν) / (3 * (1 - 2 * ν))     # Bulk modulus
         E = 9 * Kb * G / (3 * Kb + G)              # Youngs modulus

--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -48,7 +48,7 @@ ConstantElasticity(args...) = ConstantElasticity(convert.(GeoUnit, args)...)
 
 This allows setting elastic parameters by specifying 2 out of the 4 elastic parameters `G` (Elastic shear modulus), `ν` (Poisson's ratio), `E` (Young's modulus), or `Kb` (bulk modulus).
 """
-function SetConstantElasticity(; G=26e9, ν=0.5, E=nothing, Kb=nothing)
+function SetConstantElasticity(; G=26e9, ν=0.4, E=nothing, Kb=nothing)
     if (!isnothing(G) && !isnothing(ν))
         Kb = 2 * G * (1 + ν) / (3 * (1 - 2 * ν))     # Bulk modulus
         E = 9 * Kb * G / (3 * Kb + G)              # Youngs modulus

--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -48,7 +48,7 @@ ConstantElasticity(args...) = ConstantElasticity(convert.(GeoUnit, args)...)
 
 This allows setting elastic parameters by specifying 2 out of the 4 elastic parameters `G` (Elastic shear modulus), `ν` (Poisson's ratio), `E` (Young's modulus), or `Kb` (bulk modulus).
 """
-function SetConstantElasticity(; G=nothing, ν=nothing, E=nothing, Kb=nothing)
+function SetConstantElasticity(; G=26e9, ν=0.5, E=nothing, Kb=nothing)
     if (!isnothing(G) && !isnothing(ν))
         Kb = 2 * G * (1 + ν) / (3 * (1 - 2 * ν))     # Bulk modulus
         E = 9 * Kb * G / (3 * Kb + G)              # Youngs modulus

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -17,13 +17,13 @@ using GeoParams
     @test a_nd.G.val ≈ 5000.0
 
     a = SetConstantElasticity(; Kb=5e10, ν=0.43)
-    @test Value(a.E) ≈ 7.436e10Pa
+    @test Value(a.E) ≈ 2.1e10Pa
 
     a = SetConstantElasticity(; G=5e10, ν=0.43)
     @test Value(a.E) ≈ 1.43e11Pa
 
     a = SetConstantElasticity(; G=5e10, Kb=1e11)
-    @test Value(a.E) ≈ 1.4Pa
+    @test Value(a.E) ≈ 1.2857142857142856e11Pa
 
     @test isvolumetric(a) == true
 

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -17,13 +17,13 @@ using GeoParams
     @test a_nd.G.val ≈ 5000.0
 
     a = SetConstantElasticity(; Kb=5e10, ν=0.43)
-    @test Value(a.E) ≈ 2.1e10Pa
+    @test Value(a.E) ≈ 7.436e10Pa
 
     a = SetConstantElasticity(; G=5e10, ν=0.43)
     @test Value(a.E) ≈ 1.43e11Pa
 
     a = SetConstantElasticity(; G=5e10, Kb=1e11)
-    @test Value(a.E) ≈ 1.2857142857142856e11Pa
+    @test Value(a.E) ≈ 1.4Pa
 
     @test isvolumetric(a) == true
 


### PR DESCRIPTION
Using nothing for `G` and `ν` makes `SetConstantElasticity()` without any input arguments produce `NaN`s. To fix that default values without Units are set.