### PR TITLE
Test allocations

### DIFF
--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -52,30 +52,26 @@ using Test, GeoParams, StaticArrays
 
     x = ConstantDensity()
     num_alloc = @allocated compute_density!(rho, x, args)
-    num_alloc = @allocated compute_density!(rho, x, args)
-    # @show num_alloc
-    # @test num_alloc == 0
+    @test num_alloc == 0
 
     #Test allocations using ρ alias
     ρ!(rho, x, args)
     num_alloc = @allocated ρ!(rho, x, args)
-    # @test num_alloc == 0
+    @test num_alloc == 0
 
     # This does NOT allocate if I test this with @btime;
     #   yet it does while running the test here
     x = PT_Density()
     compute_density!(rho, x, args)
     num_alloc = @allocated compute_density!(rho, x, args)
-    # @show num_alloc
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0
 
     # This does NOT allocate if I test this with @btime;
     #   yet it does while running the test here
     x = Compressible_Density()
     compute_density!(rho, x, args)
     num_alloc = @allocated compute_density!(rho, x, args)
-    # @show num_alloc
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0
 
     # Read Phase diagram interpolation object
     fname = "test_data/Peridotite_dry.in"
@@ -185,15 +181,17 @@ using Test, GeoParams, StaticArrays
     # Test computing density when Mat_tup1 is provided as a tuple
     compute_density!(rho, Mat_tup1, Phases, args)
     num_alloc = @allocated compute_density!(rho, Mat_tup1, Phases, args)   #      287.416 μs (0 allocations: 0 bytes)
+    @test num_alloc == 0
+    
     @test sum(rho) / 400^2 ≈ 2945.000013499999
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0
 
     #Same test using function alias
     rho = zeros(size(Phases))
     ρ!(rho, Mat_tup1, Phases, args)
     num_alloc = @allocated compute_density!(rho, Mat_tup1, Phases, args)
     @test sum(rho) / 400^2 ≈ 2945.000013499999
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0
 
     # Test for single phase
     compute_density(MatParam, 1, (P=P[1], T=T[1]))
@@ -214,7 +212,7 @@ using Test, GeoParams, StaticArrays
 
     num_alloc = @allocated compute_density!(rho, Mat_tup1, PhaseRatio, args) #   136.776 μs (0 allocations: 0 bytes)
     @test sum(rho) / 400^2 ≈ 2945.000013499999
-    # @test num_alloc ≤ 32           # for some reason this does indicate allocations but @btime does not
+    @test num_alloc == 0           # for some reason this does indicate allocations but @btime does not
 
     # Test calling the routine with only pressure as input. 
     # This is ok for Mat_tup1, as it only has constant & P-dependent densities.

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -97,7 +97,7 @@ using GeoParams
 
     num_alloc = @allocated compute_heatcapacity!(Cp, Mat_tup, Phases, args)
     @test sum(Cp[1, 1, :]) ≈ 121399.0486067196
-    # @test num_alloc <= 32
+    @test num_alloc == 0
 
     # test if we provide phase ratios
     PhaseRatio = zeros(n, n, n, 3)
@@ -109,7 +109,7 @@ using GeoParams
     compute_heatcapacity!(Cp, Mat_tup, PhaseRatio, args)
     num_alloc = @allocated compute_heatcapacity!(Cp, Mat_tup, PhaseRatio, args)
     @test sum(Cp[1, 1, :]) ≈ 121399.0486067196
-    # @test num_alloc <= 32
+    @test num_alloc == 0
 
     # -----------------------
 
@@ -222,12 +222,12 @@ using GeoParams
     compute_conductivity!(k, Mat_tup, Phases, args)
     @test sum(k) ≈ 1.9216938849389635e6
     # num_alloc = @allocated compute_conductivity!(k, Mat_tup, Phases, args) 
-    # @test num_alloc <= 32
+    @test num_alloc == 0
 
     compute_conductivity!(k, Mat_tup, PhaseRatio, args)
     @test sum(k) ≈ 1.9216938849389635e6
     # num_alloc = @allocated compute_conductivity!(k, Mat_tup, PhaseRatio, args) 
-    # @test num_alloc <= 32
+    @test num_alloc == 0
 
     ######
 
@@ -371,7 +371,7 @@ using GeoParams
     @test Hr[50, 50, 50] ≈ 1e-6
 
     # num_alloc = @allocated compute_radioactive_heat!(Hr, Mat_tup, Phases, args)  
-    # @test num_alloc <= 32   # in the commandline this gives 0; while running the script not always
+    @test num_alloc == 0   # in the commandline this gives 0; while running the script not always
 
     compute_radioactive_heat!(Hr, Mat_tup, PhaseRatio, args)
     @test sum(Hr) ≈ 0.33715177646857664

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -80,7 +80,7 @@ using GeoParams
     compute_yieldfunction!(F, MatParam, PhaseRatio, args)
     num_alloc = @allocated compute_yieldfunction!(F, MatParam, PhaseRatio, args)
     @test maximum(F[1, 1, :]) ≈ 839745.962155614
-    # @test num_alloc <= 32
+    @test num_alloc == 0
 
     # Test plastic potential derivatives
     ## 2D


### PR DESCRIPTION
After the type stability improvements, we can uncomment the old `@test num_alloc <= 32` and replace them by `@test num_alloc == 0`
