### PR TITLE
Fix instabilities in `compute_units`

### DIFF
--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -52,14 +52,13 @@ using Test, GeoParams, StaticArrays
 
     x = ConstantDensity()
     num_alloc = @allocated compute_density!(rho, x, args)
-    num_alloc = @allocated compute_density!(rho, x, args)
     # @show num_alloc
     # @test num_alloc == 0
 
     #Test allocations using ρ alias
     ρ!(rho, x, args)
     num_alloc = @allocated ρ!(rho, x, args)
-    # @test num_alloc == 0
+    @test num_alloc == 0
 
     # This does NOT allocate if I test this with @btime;
     #   yet it does while running the test here
@@ -67,7 +66,7 @@ using Test, GeoParams, StaticArrays
     compute_density!(rho, x, args)
     num_alloc = @allocated compute_density!(rho, x, args)
     # @show num_alloc
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0 
 
     # This does NOT allocate if I test this with @btime;
     #   yet it does while running the test here
@@ -75,7 +74,7 @@ using Test, GeoParams, StaticArrays
     compute_density!(rho, x, args)
     num_alloc = @allocated compute_density!(rho, x, args)
     # @show num_alloc
-    # @test num_alloc ≤ 32
+    @test num_alloc == 0
 
     # Read Phase diagram interpolation object
     fname = "test_data/Peridotite_dry.in"
@@ -169,9 +168,9 @@ using Test, GeoParams, StaticArrays
 
     # test computing material properties
     Phases = zeros(Int64, 400, 400)
-    Phases[:, 20:end] .= 1
-    Phases[:, 200:end] .= 2
-    Phases[:, 300:end] .= 3
+    @views Phases[:,  20:end] .= 1
+    @views Phases[:, 200:end] .= 2
+    @views Phases[:, 300:end] .= 3
 
     #Phases .= 2;
     rho = zeros(size(Phases))
@@ -214,7 +213,7 @@ using Test, GeoParams, StaticArrays
 
     num_alloc = @allocated compute_density!(rho, Mat_tup1, PhaseRatio, args) #   136.776 μs (0 allocations: 0 bytes)
     @test sum(rho) / 400^2 ≈ 2945.000013499999
-    # @test num_alloc ≤ 32           # for some reason this does indicate allocations but @btime does not
+    @test num_alloc == 0           # for some reason this does indicate allocations but @btime does not
 
     # Test calling the routine with only pressure as input. 
     # This is ok for Mat_tup1, as it only has constant & P-dependent densities.

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -84,20 +84,21 @@ using StaticArrays
     @views Phases[:, :, 20:end] .= 2
 
     Cp = zeros(size(Phases))
-    T = ones(size(Phases)) * 1500
+    T = fill(1500e0, size(Phases))
     P = zeros(size(Phases))
 
     args = (; T=T)
     compute_heatcapacity!(Cp, Mat_tup, Phases, args)    # computation routine w/out P (not used in most heat capacity formulations)
-    @test sum(Cp[1, 1, :]) ≈ 121399.0486067196
+    @test sum(Cp[1, 1, k] for k in axes(Cp,3)) ≈ 121399.0486067196
 
     # check with array of constant properties (and no required input args)
     args1 = (;)
     compute_heatcapacity!(Cp, Mat_tup1, Phases, args1)    # computation routine w/out P (not used in most heat capacity formulations)
-    @test sum(Cp[1, 1, :]) ≈ 109050.0
+    @test sum(Cp[1, 1, k] for k in axes(Cp,3)) ≈ 109050.0
 
     num_alloc = @allocated compute_heatcapacity!(Cp, Mat_tup, Phases, args)
-    @test sum(Cp[1, 1, :]) ≈ 121399.0486067196
+    @test sum(Cp[1, 1, k] for k in axes(Cp,3)) ≈ 121399.0486067196
+
     @test num_alloc == 0
 
     # test if we provide phase ratios
@@ -109,7 +110,7 @@ using StaticArrays
     end
     compute_heatcapacity!(Cp, Mat_tup, PhaseRatio, args)
     num_alloc = @allocated compute_heatcapacity!(Cp, Mat_tup, PhaseRatio, args)
-    @test sum(Cp[1, 1, :]) ≈ 121399.0486067196
+    @test sum(Cp[1, 1, k] for k in axes(Cp,3)) ≈ 121399.0486067196
     @test num_alloc == 0
 
     # -----------------------
@@ -131,7 +132,7 @@ using StaticArrays
 
     # Temperature-dependent conductivity
     # dimensional
-    T = Vector{Float64}(250:100:1250)
+    T = collect(250e0:100:1250e0)
     cond2 = T_Conductivity_Whittington()
     k = compute_conductivity(cond2, T)
     @test isbits(cond2)
@@ -154,7 +155,7 @@ using StaticArrays
 
     # Temperature-dependent parameterised conductivity
     # dimensional
-    T = Vector{Float64}(250:100:1250)
+    T = collect(250e0:100:1250e0)
     cond2 = T_Conductivity_Whittington_parameterised()
     k = compute_conductivity(cond2, T)
     @test isbits(cond2)
@@ -205,8 +206,8 @@ using StaticArrays
     # test computing material properties
     n = 100
     Phases = ones(Int64, n, n, n)
-    Phases[:, :, 20:end] .= 2
-    Phases[:, :, 60:end] .= 3
+    @views Phases[:, :, 20:end] .= 2
+    @views Phases[:, :, 60:end] .= 3
 
     PhaseRatio = zeros(n, n, n, 3)
     for i in CartesianIndices(Phases)
@@ -216,7 +217,7 @@ using StaticArrays
     end
 
     k = zeros(size(Phases))
-    T = ones(size(Phases)) * 1500
+    T = fill(1500e0, size(Phases))
     P = zeros(size(Phases))
     args = (P=P, T=T)
 
@@ -235,9 +236,9 @@ using StaticArrays
     # TP-dependent conductivity for different predefines cases
     T = Vector{Float64}(250:100:1250)
     P = 1e6 * ones(size(T)) / ustrip(uconvert(Pa, 1MPa))  # must be in MPa!
-    List = ["LowerCrust" "Mantle" "OceanicCrust" "UpperCrust"]
-    Sol_kT = [20.55712932736763 28.700405819019323 20.55712932736763 19.940302462417037]
-    for i in 1:length(List)
+    List = "LowerCrust", "Mantle", "OceanicCrust", "UpperCrust"
+    Sol_kT = 20.55712932736763, 28.700405819019323, 20.55712932736763, 19.940302462417037
+    for i in eachindex(List)
         k_TP = Set_TP_Conductivity(List[i])
         k = compute_conductivity(k_TP, P, T)         # note that P must be in MPa
         @test sum(k) ≈ Sol_kT[i]
@@ -277,8 +278,8 @@ using StaticArrays
     # test computing material properties
     n = 100
     Phases = ones(Int64, n, n, n)
-    Phases[:, :, 20:end] .= 2
-    Phases[:, :, 60:end] .= 3
+    @views Phases[:, :, 20:end] .= 2
+    @views Phases[:, :, 60:end] .= 3
 
     PhaseRatio = zeros(n, n, n, 3)
     for i in CartesianIndices(Phases)
@@ -288,7 +289,7 @@ using StaticArrays
     end
 
     Hl = zeros(size(Phases))
-    z = ones(size(Phases)) * 10e3
+    z = fill(10e3, size(Phases))
     args = (;)
 
     compute_latent_heat!(Hl, Mat_tup, Phases, args)
@@ -348,8 +349,8 @@ using StaticArrays
     # test computing material properties
     n = 100
     Phases = ones(Int64, n, n, n)
-    Phases[:, :, 20:end] .= 2
-    Phases[:, :, 60:end] .= 3
+    @views Phases[:, :, 20:end] .= 2
+    @views Phases[:, :, 60:end] .= 3
 
     PhaseRatio = zeros(n, n, n, 3)
     for i in CartesianIndices(Phases)
@@ -359,7 +360,7 @@ using StaticArrays
     end
 
     Hr = zeros(size(Phases))
-    z = ones(size(Phases)) * 10e3
+    z = fill(10e3, size(Phases))
     args = (z=z,)
 
     compute_radioactive_heat!(Hr, Mat_tup, Phases, args)


### PR DESCRIPTION
Fixes the type instabilities in  `compute_units` which had an impact in the non/dimensionalization functions.

```julia
CharUnits_GEO = GEO_units(; viscosity=1e19, length=1000km)
```

Main branch
```julia-repl
julia> @btime nondimensionalize($(10cm / yr, CharUnits_GEO)...)
  4.827 μs (66 allocations: 2.69 KiB)
```

This PR
```julia-repl
julia> @btime nondimensionalize($(10cm / yr, CharUnits_GEO)...)
  161.724 ns (5 allocations: 80 bytes)
```

The remaining allocations are because `GeoUnits` is not parameterized ([here](https://github.com/JuliaGeodynamics/GeoParams.jl/blob/a21703cb285cf07479e3023677d21827b67f9f29/src/Units.jl#L312)). I'm not sure it's worth the effort though.