### PR TITLE
Add latent heat by modifying heat capacity 

### DIFF
--- a/docs/src/man/latentheat.md
+++ b/docs/src/man/latentheat.md
@@ -1,12 +1,23 @@
 # Latent heat
 
 # Methods
-Latent heat (of crystallisation) is defined as 
+Latent heat (of crystallisation) can be implemented as a source term (usually numerically not very stable):
 ```@docs
-GeoParams.MaterialParameters.LatentHeat.ConstantLatentHeat
+ConstantLatentHeat
 ```
+Alternatively, you can implement it by modifying the heat capacity, which is often numerically better.
+```@docs
+Latent_HeatCapacity
+```
+
 # Computational routines
-To compute, use this:
+To compute with the source term, use this:
 ```@docs
 GeoParams.MaterialParameters.LatentHeat.compute_latent_heat
+```
+
+If you modify the heat capacity, you simply use this in your thermal computations:
+To compute with the source term, use this:
+```@docs
+compute_heatcapacity
 ```

--- a/src/Energy/Conductivity.jl
+++ b/src/Energy/Conductivity.jl
@@ -23,7 +23,6 @@ export compute_conductivity,                       # calculation routines
     Set_TP_Conductivity                         # Routine to set pre-defined parameters
 
 include("../Computations.jl")
-#include("../Utils.jl")
 
 # Constant Conductivity -------------------------------------------------------
 """
@@ -545,7 +544,7 @@ ________________________________________________________________________________
 
 compute_conductivity!(k::AbstractArray{T,N}, PhaseRatios::AbstractArray{T, M}, P::AbstractArray{<:AbstractFloat,N},T::AbstractArray{<:AbstractFloat,N}, MatParam::AbstractArray{<:AbstractMaterialParamsStruct})
 
-In-place computation of density `rho` for the whole domain and all phases, in case a vector with phase properties `MatParam` is provided, along with `P` and `T` arrays.
+In-place computation of conductivity `k` for the whole domain and all phases, in case a vector with phase properties `MatParam` is provided, along with `P` and `T` arrays.
 This assumes that the `PhaseRatio` of every point is specified as an Integer in the `PhaseRatios` array, which has one dimension more than the data arrays (and has a phase fraction between 0-1)
 """
 compute_conductivity(args::Vararg{Any, N}) where N = compute_param(compute_conductivity, args...)

--- a/src/Energy/HeatCapacity.jl
+++ b/src/Energy/HeatCapacity.jl
@@ -117,11 +117,17 @@ end
 """
     Latent_HeatCapacity(Cp=ConstantHeatCapacity(), Q_L=400kJ/kg)
     
-This takes the effects of latent heat into account by modifying the heat capacity:
-```math  
-    C_p  = C_p + \\frac{\\partial \\phi}{\\partial T} Q_L
+This takes the effects of latent heat into account by modifying the heat capacity in the temperature equation:
+
+```math
+\\rho C_p^{\\textrm{new}} \\frac{\\partial T}{\\partial t}  = \\frac{\\partial }{\\partial x_i} \\left( k \\frac{\\partial T}{\\partial x_i} \\right)  + H_s
 ```
-where ``Q_L`` is the latent heat [``kJ/kg``], and ``\\frac{\\partial \\phi}{\\partial T}`` is the derivative of the melt fraction with respect to temperature.
+
+with
+```math  
+C_p^{\\textrm{new}}  = C_p + \\frac{\\partial \\phi}{\\partial T} Q_L
+```
+where ``Q_L`` is the latent heat [``kJ/kg``], and ``\\frac{\\partial \\phi}{\\partial T}`` is the derivative of the melt fraction with respect to temperature
 
 """
 @with_kw_noshow struct Latent_HeatCapacity{T,U} <: AbstractHeatCapacity{T}

--- a/src/Energy/LatentHeat.jl
+++ b/src/Energy/LatentHeat.jl
@@ -1,7 +1,7 @@
 module LatentHeat
 
 # This implements latent heat. There are two options:
-# 1) Constant latent heat as a source term to the enery equation (usually numerically unstable)
+# 1) Constant latent heat as a source term to the energy equation (usually numerically unstable)
 # 2) Latent heat by modifying heat capacity (usually more stable)
 # Note that 1) is implemented in this module, but that 2) is added to the HeatCapacity module
 

--- a/src/Energy/LatentHeat.jl
+++ b/src/Energy/LatentHeat.jl
@@ -1,12 +1,16 @@
 module LatentHeat
 
-# If you want to add a new method here, feel free to do so. 
-# Remember to also export the function name in GeoParams.jl (in addition to here)
+# This implements latent heat. There are two options:
+# 1) Constant latent heat as a source term to the enery equation (usually numerically unstable)
+# 2) Latent heat by modifying heat capacity (usually more stable)
+# Note that 1) is implemented in this module, but that 2) is added to the HeatCapacity module
 
 using Parameters, LaTeXStrings, Unitful
 using ..Units
 using GeoParams: AbstractMaterialParam
 using ..MaterialParameters: MaterialParamsInfo
+using ..HeatCapacity: AbstractHeatCapacity, ConstantHeatCapacity
+
 import Base.show, GeoParams.param_info
 
 abstract type AbstractLatentHeat{T} <: AbstractMaterialParam end
@@ -14,10 +18,10 @@ abstract type AbstractLatentHeat{T} <: AbstractMaterialParam end
 export compute_latent_heat,                  # calculation routines
     compute_latent_heat!,
     param_info,
-    ConstantLatentHeat                  # constant
-
+    ConstantLatentHeat                      # constant (as source)
+    
 include("../Computations.jl")
-#include("../Utils.jl")
+
 # Constant  -------------------------------------------------------
 """
     ConstantLatentHeat(Q_L=400kJ/kg)
@@ -58,6 +62,7 @@ function show(io::IO, g::ConstantLatentHeat)
 end
 #-------------------------------------------------------------------------
 
+
 # Help info for the calculation routines
 """
     Ql = compute_latent_heat(s:<AbstractLatentHeat)
@@ -65,7 +70,6 @@ end
 Returns the latent heat `Q_L`
 
 """
-#compute_latent_heat()
 
 # Computational routines needed for computations with the MaterialParams structure 
 function compute_latent_heat(s::AbstractMaterialParamsStruct, args)

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -270,7 +270,7 @@ export compute_gravity,                                # computational routines
 # Energy parameters: Heat Capacity, Thermal conductivity, latent heat, radioactive heat
 using .MaterialParameters.HeatCapacity
 export compute_heatcapacity,
-    compute_heatcapacity!, ConstantHeatCapacity, T_HeatCapacity_Whittington
+    compute_heatcapacity!, ConstantHeatCapacity, T_HeatCapacity_Whittington, Latent_HeatCapacity
 
 using .MaterialParameters.Conductivity
 export compute_conductivity,


### PR DESCRIPTION
There are two ways to implement latent heat in the energy equation: explicitly by adding it as a source term or implicitly. The explicit manner was already available `GeoParams`; this PR adds the implicit method which implements it by modifying the thermal heat capacity (making it temperature-dependent).

The are several texts on how to implement this; since some lessons learned seemed to have gone forgotten, I recently summarised this [here](https://pubs.geoscienceworld.org/gsa/geosphere/article/19/4/1006/624461/Zircon-age-spectra-to-quantify-magma-evolution).

In short, the energy equation (w/out advection) is:
```math
\rho c_p \frac{\partial T}{\partial t}  ) = \frac{\partial }{\partial x_i} \left( k   \frac{\partial T}{\partial x_i}  \right)  + H_s + \rho Q_L\frac{\partial \phi_s}{\partial t}  
```
where $H_s$ are heat sources, $\phi_s=(1-\phi)$ is the solid fraction, $\phi$ the melt fraction, $k$ thermal conductivity, $\rho$ density, $c_p$ heat capacity and $Q_L$ the latent heat. 

Using the chain rule we can rewrite the last term as
```math
\rho c_p \frac{\partial T}{\partial t}  =\frac{\partial }{\partial x_i} \left( k   \frac{\partial T}{\partial x_i}  \right)  + H_s + \rho Q_L\frac{\partial \phi_s}{\partial T}\frac{\partial T}{\partial t} . 
```
Since 
```math
\frac{\partial \phi_s}{\partial T}   = -\frac{\partial \phi}{\partial T},  
```
```math
\rho c_p \frac{\partial T}{\partial t}  =\frac{\partial }{\partial x_i} \left( k   \frac{\partial T}{\partial x_i}  \right)  + H_s - \rho Q_L\frac{\partial \phi}{\partial T}\frac{\partial T}{\partial t},
```
we obtain:
```math
\rho \left( c_p + Q_L\frac{\partial \phi}{\partial T} \right) \frac{\partial T}{\partial t}  =\frac{\partial }{\partial x_i} \left( k   \frac{\partial T}{\partial x_i}  \right)  + H_s. 
```

From this it is clear that we can rewrite the original equation as:
```math
\rho c_p^{\textrm{new}} \frac{\partial T}{\partial t}  = \frac{\partial }{\partial x_i} \left( k   \frac{\partial T}{\partial x_i}  \right)  + H_s,
```
with
```math
c_p^{\textrm{new}} = c_p + Q_L\frac{\partial \phi}{\partial T}.
```

So we can implement latent heat my modifying the heat capacity. This formulation is numerically more stable than by adding it as a source term. A point to remember, though, is that it is crucial that  $\frac{\partial \phi}{\partial T}$ does not have discontinuities. Many of the parameterisations in use in the petrology/volcanological community do have jumps around $\phi=0$ or $\phi=1$ which results in non-converging  numerical solutions.

With the current PR, you can add latent heat as:
```Julia
julia> x1  = Latent_HeatCapacity(Q_L=500kJ/kg)
Latent heat through modifying heat capacity: Cp = Cp + dϕdT*500.0 kJ kg⁻¹·⁰; Cp=Constant heat capacity: cp=1050.0 J kg⁻¹·⁰ K⁻¹·⁰
```
Note that you can use any of the available heat capacity functions, including temperature-dependent ones:
```Julia
julia> x2 = Latent_HeatCapacity(Cp=T_HeatCapacity_Whittington())
Latent heat through modifying heat capacity: Cp = Cp + dϕdT*400.0 kJ kg⁻¹·⁰; Cp=T-dependent heat capacity following Whittington et al. (2009) for average crust. 
```
