### PR TITLE
Fixes bug in `Latent_HeatCapacity`

### DIFF
--- a/src/Energy/HeatCapacity.jl
+++ b/src/Energy/HeatCapacity.jl
@@ -95,9 +95,9 @@ end
 # Calculation routine
 @inline function compute_heatcapacity(
     a::T_HeatCapacity_Whittington{_T}; 
-    T = zero(precision(a)),
+    T = zero(_T),
     kwargs...
-    ) where _T
+) where _T
     @unpack_val a0, a1, b0, b1, c0, c1, molmass, Tcutoff = a
 
     cp = a0 / molmass
@@ -144,10 +144,10 @@ end
 
 # Calculation routine
 @inline function compute_heatcapacity(
-    a::Latent_HeatCapacity; 
-    dϕdT = zero(precision(a)),
+    a::Latent_HeatCapacity{_T}; 
+    dϕdT = zero(_T),
     kwargs...
-    )
+) where _T
     @unpack_val Q_L = a
 
     Cp = compute_heatcapacity(a.Cp, kwargs)

--- a/src/Energy/HeatCapacity.jl
+++ b/src/Energy/HeatCapacity.jl
@@ -146,6 +146,7 @@ end
 @inline function compute_heatcapacity(
     a::Latent_HeatCapacity{_T}; 
     dϕdT = zero(_T),
+    kwargs...
 ) where _T
     @unpack_val Q_L = a
 


### PR DESCRIPTION
Fixes the bug caused by not having `dϕdT` in the args when calling `Latent_HeatCapacity`:

```julia
x = Latent_HeatCapacity(Cp=ConstantHeatCapacity(), Q_L=400kJ/kg)
a = (; T = 10e0) 

compute_heatcapacity(x, a)
```

would throw

```julia-repl
In [13]: compute_heatcapacity(x, a)
ERROR: MethodError: no method matching precision(::Latent_HeatCapacity{Float64, Unitful.FreeUnits{(kg^-1.0, kJ), 𝐋^2.0 𝐓^-2.0, nothing}}  
)

Closest candidates are:
  precision(::BigFloat; base)
   @ Base mpfr.jl:898
  precision(::ForwardDiff.Dual; base)
   @ ForwardDiff C:\Users\albert\.julia\packages\ForwardDiff\PcZ48\src\dual.jl:303
  precision(::Type{D}; base) where D<:ForwardDiff.Dual
   @ ForwardDiff C:\Users\albert\.julia\packages\ForwardDiff\PcZ48\src\dual.jl:304
  ...

Stacktrace:
 [1] compute_heatcapacity
   @ c:\Users\albert\Desktop\GeoParams.jl\GeoParams.jl\src\Energy\HeatCapacity.jl:146 [inlined]
 [2] compute_heatcapacity(s::Latent_HeatCapacity{Float64, Unitful.FreeUnits{…}}, args::@NamedTuple{T::Float64})
   @ GeoParams.MaterialParameters.HeatCapacity c:\Users\albert\Desktop\GeoParams.jl\GeoParams.jl\src\Energy\HeatCapacity.jl:179
 [3] top-level scope
   @ c:\Users\albert\Desktop\GeoParams.jl\GeoParams.jl\test\test_Energy.jl:560
Some type information was truncated. Use `show(err)` to see complete types.
```

because `precision` is not defined for `Latent_HeatCapacity`