### PR TITLE
Extractor methods

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -8,7 +8,7 @@ using Parameters, LaTeXStrings, Unitful
 using ..Units
 using GeoParams: AbstractMaterialParam, AbstractConstitutiveLaw, AbstractComposite
 import GeoParams: param_info, fastpow, pow_check, nphase, ntuple_idx, @print, @pow, str2tuple, uint2str
-import GeoParams: second_invariant, second_invariant_staggered, value_and_partial
+import GeoParams: second_invariant, second_invariant_staggered, value_and_partial, @extractors, add_extractor_functions
 using BibTeX
 using ..MaterialParameters: MaterialParamsInfo
 import Base.show

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -8,7 +8,7 @@ module Density
 using Parameters, Unitful, LaTeXStrings
 using ..Units
 using ..PhaseDiagrams
-using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct, @extractors, add_extractor_functions
 import ..Units: isdimensional
 using ..MaterialParameters: No_MaterialParam, MaterialParamsInfo
 import Base.show, GeoParams.param_info
@@ -371,5 +371,10 @@ This assumes that the `PhaseRatio` of every point is specified as an Integer in 
 @inline compute_density!(args::Vararg{Any, N})      where N = compute_param!(compute_density, args...) #Multiple dispatch to rest of routines found in Computations.jl
 @inline compute_density(args::Vararg{Any, N})       where N = compute_param(compute_density, args...)
 @inline compute_density_ratio(args::Vararg{Any, N}) where N = compute_param_times_frac(compute_density, args...)
+
+# extractor methods
+for type in (ConstantDensity, PT_Density, Compressible_Density, T_Density, MeltDependent_Density)
+    @extractors(type, :Density)
+end
 
 end

--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -26,7 +26,6 @@ export compute_εII,            # calculation routines
     get_Kb
 
 # ConstantElasticity  -------------------------------------------------------
-
 """
     ConstantElasticity(G, ν, K, E)
 
@@ -94,14 +93,17 @@ end
 @inline iselastic(v::AbstractElasticity) = true
 @inline iselastic(v) = false
 
-for modulus in (:G, :Kb)
-    fun = Symbol("get_$(string(modulus))")
-    @eval begin
-        @inline $(fun)(a::ConstantElasticity) = a.$(modulus).val
-        @inline $(fun)(a::AbstractMaterialParamsStruct) = isempty(a.Elasticity) ? Inf : $(fun)(a.Elasticity[1])
-        @inline $(fun)(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
-    end
-end
+# for modulus in (:G, :Kb)
+#     fun = Symbol("get_$(string(modulus))")
+#     @eval begin
+#         @inline $(fun)(a::ConstantElasticity) = a.$(modulus).val
+#         @inline $(fun)(a::AbstractMaterialParamsStruct) = isempty(a.Elasticity) ? Inf : $(fun)(a.Elasticity[1])
+#         @inline $(fun)(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
+#     end
+# end
+
+# extractor methods
+@extractors(SetConstantElasticity, :Elasticity)
 
 # Calculation routines
 """

--- a/src/Elasticity/Elasticity.jl
+++ b/src/Elasticity/Elasticity.jl
@@ -103,7 +103,7 @@ end
 # end
 
 # extractor methods
-@extractors(SetConstantElasticity, :Elasticity)
+@extractors(ConstantElasticity, :Elasticity)
 
 # Calculation routines
 """

--- a/src/Energy/Conductivity.jl
+++ b/src/Energy/Conductivity.jl
@@ -7,7 +7,7 @@ module Conductivity
 
 using Parameters, LaTeXStrings, Unitful
 using ..Units
-using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct, @extractors, add_extractor_functions
 using ..MaterialParameters: MaterialParamsInfo
 import Base.show, GeoParams.param_info
 

--- a/src/Energy/Conductivity.jl
+++ b/src/Energy/Conductivity.jl
@@ -550,4 +550,9 @@ This assumes that the `PhaseRatio` of every point is specified as an Integer in 
 compute_conductivity(args::Vararg{Any, N}) where N = compute_param(compute_conductivity, args...)
 compute_conductivity!(args::Vararg{Any, N}) where N = compute_param!(compute_conductivity, args...)
 
+# extractor methods
+for type in (ConstantConductivity, T_Conductivity_Whittington, T_Conductivity_Whittington_parameterised, TP_Conductivity)
+    @extractors(type, :Conductivity)
+end
+
 end

--- a/src/Energy/Energy.jl
+++ b/src/Energy/Energy.jl
@@ -1,0 +1,26 @@
+include("HeatCapacity.jl")
+include("Conductivity.jl")
+include("LatentHeat.jl")
+include("RadioactiveHeat.jl")
+include("Shearheating.jl")
+
+# export reduce_energy_source_terms
+
+# # Single phase methods
+
+# @inline function reduce_energy_source_terms(f::NTuple{N, Any}, rheology::MaterialParams, specific_args) where N
+#     sum(_reduce_energy_source_terms(fᵢ, rheology, specific_argsᵢ) for (fᵢ, specific_argsᵢ) in zip(f, specific_args))
+# end
+
+# @inline function reduce_energy_source_terms(f::NTuple{N, Any}, rheology::MaterialParams, specific_args, source_terms::Vararg{NH, T}) where {N, NH, T}
+#     H = reduce_energy_source_terms(f, rheology, specific_args)
+#     return sum(source_terms; init = H)
+# end
+
+# @inline function _reduce_energy_source_terms(f::F, rheology::MaterialParams, specific_args) where F
+#     f(rheology, specific_args...)
+# end
+
+# @inline function _reduce_energy_source_terms(f::F, rheology::MaterialParams, specific_args::Union{NamedTuple, Tuple{}}) where F
+#     f(rheology, specific_args)
+# end

--- a/src/Energy/HeatCapacity.jl
+++ b/src/Energy/HeatCapacity.jl
@@ -263,7 +263,6 @@ compute_heatcapacity!()
 compute_heatcapacity(args::Vararg{Any, N}) where N = compute_param(compute_heatcapacity, args...)
 compute_heatcapacity!(args::Vararg{Any, N}) where N = compute_param!(compute_heatcapacity, args...)
 
-
 # In case just temperature is provided
 #=
 function compute_heatcapacity!(
@@ -275,5 +274,10 @@ function compute_heatcapacity!(
     return compute_param!(compute_heatcapacity, Cp, MatParam, Phases, nothing, T)
 end
 =#
+
+# extractor methods
+for type in (ConstantHeatCapacity, T_HeatCapacity_Whittington, Latent_HeatCapacity)
+    @extractors(type, :HeatCapacity)
+end
 
 end

--- a/src/Energy/HeatCapacity.jl
+++ b/src/Energy/HeatCapacity.jl
@@ -7,7 +7,7 @@ module HeatCapacity
 
 using Parameters, LaTeXStrings, Unitful
 using ..Units
-using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct, @extractors, add_extractor_functions
 import Base.show, GeoParams.param_info
 import ..Units: isdimensional
 using ..MaterialParameters: MaterialParamsInfo

--- a/src/Energy/RadioactiveHeat.jl
+++ b/src/Energy/RadioactiveHeat.jl
@@ -5,7 +5,7 @@ module RadioactiveHeat
 
 using Parameters, LaTeXStrings, Unitful
 using ..Units
-using GeoParams: AbstractMaterialParam
+using GeoParams: AbstractMaterialParam, @extractors, add_extractor_functions
 using ..MaterialParameters: MaterialParamsInfo
 import Base.show, GeoParams.param_info
 
@@ -165,5 +165,10 @@ end
 
 compute_radioactive_heat(args::Vararg{Any, N}) where N = compute_param(compute_radioactive_heat, args...)
 compute_radioactive_heat!(args::Vararg{Any, N}) where N = compute_param!(compute_radioactive_heat, args...)
+
+# extractor methods
+for type in (ConstantRadioactiveHeat, ExpDepthDependentRadioactiveHeat)
+    @extractors(type, :RadioactiveHeat)
+end
 
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -164,28 +164,7 @@ function add_extractor_functions(::Type{_T}, param_field) where _T
             $fun(a::$_T) = a.$(f).val
             if $checker
                 $fun(a::AbstractMaterialParamsStruct) = isempty(a.$(param_field)) ? 0.0 : $(fun)(a.$(param_field)[1])
-                # $fun(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
-            end
-        end
-    end
-end
-
-
-function add_extractor_functions(types::NTuple{N, Any}, param_field) where N
-    for i in 1:N
-        _T = typeof(types[i])
-        fields = fieldnames(_T)
-        for f in fields
-            fun = Symbol("get_$(string(f))")
-            @eval GeoParams begin 
-                $fun(a::$_T) = a.$(f).val
-            end
-
-            if i == 1
-                @eval GeoParams begin 
-                    $fun(a::AbstractMaterialParamsStruct) = isempty(a.$(param_field)) ? 0.0 : $(fun)(a.$(param_field)[1])
-                    $fun(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
-                end
+                $fun(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
             end
         end
     end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -148,3 +148,45 @@ end
     df =  f(ForwardDiff.Dual{T}(x, one(x)), )     
     return df.value, ForwardDiff.extract_derivative(T, df) 
 end
+
+macro extractors(type, field)
+    esc(quote
+        add_extractor_functions($type, $field)
+    end)
+end
+
+function add_extractor_functions(::Type{_T}, param_field) where _T
+    fields = fieldnames(_T)
+    for f in fields
+        fun = Symbol("get_$(string(f))")
+        checker = !isdefined(GeoParams, fun)
+        @eval GeoParams begin 
+            $fun(a::$_T) = a.$(f).val
+            if $checker
+                $fun(a::AbstractMaterialParamsStruct) = isempty(a.$(param_field)) ? 0.0 : $(fun)(a.$(param_field)[1])
+                # $fun(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
+            end
+        end
+    end
+end
+
+
+function add_extractor_functions(types::NTuple{N, Any}, param_field) where N
+    for i in 1:N
+        _T = typeof(types[i])
+        fields = fieldnames(_T)
+        for f in fields
+            fun = Symbol("get_$(string(f))")
+            @eval GeoParams begin 
+                $fun(a::$_T) = a.$(f).val
+            end
+
+            if i == 1
+                @eval GeoParams begin 
+                    $fun(a::AbstractMaterialParamsStruct) = isempty(a.$(param_field)) ? 0.0 : $(fun)(a.$(param_field)[1])
+                    $fun(a::NTuple{N, AbstractMaterialParamsStruct}, phase) where N = nphase($(fun), phase, a)
+                end
+            end
+        end
+    end
+end

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -29,6 +29,7 @@ using Test, GeoParams, StaticArrays
     # Define a linear viscous creep law
     x1 = ConstantDensity(; ρ=2900kg / m^3)
     @test x1.ρ.val == 2900
+    @test GeoParams.get_ρ(x1) == 2900
 
     x1 = nondimensionalize(x1, CharUnits_GEO)
     @test x1.ρ.val ≈ 2.9e-16
@@ -36,6 +37,8 @@ using Test, GeoParams, StaticArrays
     x2 = PT_Density()
     @test x2.α.val == 3e-5
     @test x2.ρ0.val == 2900.0
+    @test GeoParams.get_α(x2) == 3e-5
+    @test GeoParams.get_ρ0(x2) == 2900
 
     x2 = nondimensionalize(x2, CharUnits_GEO)
     @test x2.T0.val ≈ 0.21454659702313156
@@ -77,6 +80,9 @@ using Test, GeoParams, StaticArrays
     # This does NOT allocate if I test this with @btime;
     #   yet it does while running the test here
     x = Compressible_Density()
+    @test GeoParams.get_P0(x) == x.P0.val
+    @test GeoParams.get_β(x) == x.β.val
+    @test GeoParams.get_ρ0(x) == x.ρ0.val
     compute_density!(rho, x, args)
     num_alloc = @allocated compute_density!(rho, x, args)
     # @show num_alloc
@@ -93,6 +99,16 @@ using Test, GeoParams, StaticArrays
     args = (P=1e7, T=1500.0)
     @test compute_density(PD_data, args) ≈ 3054.8671154189938 # named tuple syntax
     @test compute_density(PD_data; P=1e7, T=1500.0) ≈ 3054.8671154189938 # optional parameter syntax
+
+    #  test extractors for more complex data strutcs
+    r = SetMaterialParams(;
+        Name="Crust",
+        Phase=1,
+        Density=ConstantDensity(; ρ=2900kg / m^3),
+    )
+    R = (r,r)
+    @test GeoParams.get_ρ(r) == 2900
+    @test GeoParams.get_ρ(R, 1) == 2900
 
     # Do the same but non-dimensionalize the result
     CharDim = GEO_units()

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -14,6 +14,7 @@ using StaticArrays
     info = param_info(cp1)
     @test isbits(cp1)
     @test cp1.cp.val == 1050.0
+    @test GeoParams.get_cp(cp1) ==  1050.0
 
     cp1_nd = cp1
     cp1_nd = nondimensionalize(cp1_nd, CharUnits_GEO)
@@ -30,6 +31,7 @@ using StaticArrays
     args = (; T=T)
     compute_heatcapacity!(Cp, cp2, args)
     @test sum(Cp) ≈ 11667.035717418683
+    @test GeoParams.get_Tcutoff(cp2) ==  846.0
 
     # nondimensional
     cp2_nd = T_HeatCapacity_Whittington()
@@ -139,6 +141,7 @@ using StaticArrays
     @test isbits(cond)
     @test NumValue(cond.k) == 3.0
     @test cond.k.unit == u"W" / K / m
+    @test GeoParams.get_k(cond) ==  3.0
 
     cond = nondimensionalize(cond, CharUnits_GEO)
     @test NumValue(cond.k) ≈ 3.8194500000000007


### PR DESCRIPTION
Sometimes I need to extract parameters from different types which they may be inside tuples of different phases or whatever. This PR adds the `@extractors` macro to automatically generate functions to extract variables from a `struct`. An example for the `AbstractDensity` case [here](https://github.com/JuliaGeodynamics/GeoParams.jl/blob/04bcbfdc030b9aec5a6c5564ca6c0ff00fdac181/src/Density/Density.jl#L375-L379)
```
for type in (ConstantDensity, PT_Density, Compressible_Density, T_Density, MeltDependent_Density)
    @extractors(type, :Density)
end
```

generates e.g. `get_α(x::PT_Density) = x.α.val` and the appropriate methods for `AbstractMaterialParamsStruct` and `Tuple{N, AbstractMaterialParamsStruct}`. 

In action:
```julia-repl
In [1]: using GeoParams

In [1]: x = PT_Density()
P/T-dependent density: ρ0=2900.0 kg m^-3.0, α=3.0e-5 K^-1.0, β=1.0e-9 Pa^-1.0, T0=0.0 °C, P0=0.0 MPa

In [2]: GeoParams.get_α(x)
3.0e-5
```