### PR TITLE
Viscosity methods for linear rheologies

### DIFF
--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -263,7 +263,8 @@ export compute_viscosity_εII,
     compute_elastoviscosity,
     compute_elastoviscosity_εII,
     compute_elastoviscosity_τII,
-    compute_viscosity
+    compute_viscosity,
+    compute_elasticviscosity
 
 # Gravitational Acceleration
 using .MaterialParameters.GravitationalAcceleration

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -262,7 +262,8 @@ export compute_viscosity_εII,
     compute_viscosity_τII,
     compute_elastoviscosity,
     compute_elastoviscosity_εII,
-    compute_elastoviscosity_τII
+    compute_elastoviscosity_τII,
+    compute_viscosity
 
 # Gravitational Acceleration
 using .MaterialParameters.GravitationalAcceleration

--- a/src/Viscosity/Viscosity.jl
+++ b/src/Viscosity/Viscosity.jl
@@ -17,7 +17,7 @@ Compute effective viscosity given a 2nd invariant of the deviatoric strain rate 
 end
 
 @inline compute_viscosity_εII(v::LinearViscous, εII, args) = v.η.val
-@inline compute_viscosity_εII(v::ConstantElasticity, εII, args) = v.G.val * args.dt
+@inline compute_viscosity_εII(v::ConstantElasticity, εII, args) = v.G * args.dt
 
 # compute effective "creep" viscosity from deviatoric stress tensor
 """
@@ -32,7 +32,7 @@ Compute effective viscosity given a 2nd invariant of the deviatoric stress tenso
 end
 
 @inline compute_viscosity_τII(v::LinearViscous, τII, args) = v.η.val
-@inline compute_viscosity_τII(v::ConstantElasticity, τII, args) = v.G.val * args.dt
+@inline compute_viscosity_τII(v::ConstantElasticity, τII, args) = v.G * args.dt
 
 for fn in (:compute_viscosity_εII, :compute_viscosity_τII)
     @eval begin
@@ -129,7 +129,7 @@ end
 end
 
 # compute effective "visco-elastic" viscosity
-@inline compute_elastoviscosity(v::ConstantElasticity, η, dt) = (inv(η) + inv(v.G.val * dt)) |> inv
+@inline compute_elastoviscosity(v::ConstantElasticity, η, dt) = (inv(η) + inv(v.G * dt)) |> inv
 @inline compute_elastoviscosity(G, η, dt) = (inv(η) + inv(G * dt)) |> inv
 @inline compute_elastoviscosity(v::ConstantElasticity, η, args::NamedTuple) = compute_elastoviscosity(v, η, args.dt)
 @inline compute_elastoviscosity(G, η, args::NamedTuple) = compute_elastoviscosity(G, η, args.dt)
@@ -184,7 +184,7 @@ end
 # special cases for constant viscosity and elasticity 
 
 @inline compute_viscosity(v::LinearViscous; kwargs...) = v.η.val
-@inline compute_viscosity(v::ConstantElasticity; dt = 0.0, kwargs...) = v.G.val * dt
+@inline compute_viscosity(v::ConstantElasticity; dt = 0.0, kwargs...) = v.G * dt
 @inline compute_viscosity(v::Union{LinearViscous,ConstantElasticity}, kwargs) = compute_viscosity(v; kwargs...)
 @inline compute_viscosity(v, kwargs) = throw("compute_viscosity only works for linear rheologies")
 

--- a/src/Viscosity/Viscosity.jl
+++ b/src/Viscosity/Viscosity.jl
@@ -1,8 +1,3 @@
-export compute_viscosity_εII,
-    compute_viscosity_τII,
-    compute_viscosity_II,
-    compute_elastoviscosity
-
 # extract elements from composite rheology
 @inline elements(v::Union{CompositeRheology, Parallel}) = v.elements
 
@@ -16,11 +11,13 @@ export compute_viscosity_εII,
 Compute effective viscosity given a 2nd invariant of the deviatoric strain rate tensor, extra parameters are passed as a named tuple, e.g., (;T=T) 
 """
 @inline function compute_viscosity_εII(v::AbstractConstitutiveLaw, εII, args)
-
     τII = compute_τII(v, εII, args)
     η = _viscosity(τII, εII)
     return η
 end
+
+@inline compute_viscosity_εII(v::LinearViscous, εII, args) = v.η.val
+@inline compute_viscosity_εII(v::ConstantElasticity, εII, args) = v.G.val * args.dt
 
 # compute effective "creep" viscosity from deviatoric stress tensor
 """
@@ -29,11 +26,13 @@ end
 Compute effective viscosity given a 2nd invariant of the deviatoric stress tensor and, extra parameters are passed as a named tuple, e.g., (;T=T) 
 """
 @inline function compute_viscosity_τII(v::AbstractConstitutiveLaw, τII, args)
-
     εII = compute_εII(v, τII, args)
     η = _viscosity(τII, εII)
     return η
 end
+
+@inline compute_viscosity_τII(v::LinearViscous, τII, args) = v.η.val
+@inline compute_viscosity_τII(v::ConstantElasticity, τII, args) = v.G.val * args.dt
 
 for fn in (:compute_viscosity_εII, :compute_viscosity_τII)
     @eval begin
@@ -179,5 +178,48 @@ end
         η = 0.0
         Base.@nexprs $N i -> !isplastic(v[i]) && (η += inv(fn(v[i], II, args)))
         return inv(η)
+    end
+end
+
+# special cases for constant viscosity and elasticity 
+
+@inline compute_viscosity(v::LinearViscous; kwargs...) = v.η.val
+@inline compute_viscosity(v::ConstantElasticity; dt = 0.0, kwargs...) = v.G.val * dt
+@inline compute_viscosity(v::Union{LinearViscous,ConstantElasticity}, kwargs) = compute_viscosity(v; kwargs...)
+@inline compute_viscosity(v, kwargs) = throw("compute_viscosity only works for linear rheologies")
+
+# compute effective "creep" viscosity from strain rate tensor given a composite rheology
+@inline function compute_viscosity(v::CompositeRheology, args)
+    return compute_viscosity(elements(v), args)
+end
+
+@generated function compute_viscosity(v::NTuple{N, AbstractConstitutiveLaw}, args) where {N}
+    quote
+        Base.@_inline_meta
+        η = 0.0
+        Base.@nexprs $N i -> !isplastic(v[i]) && (η += inv(compute_viscosity(v[i], args)))
+        return inv(η)
+    end
+end
+
+# single phase versions
+@inline compute_viscosity(v::MaterialParams, args::Vararg{Any, N}) where {N} = compute_viscosity(v.CompositeRheology[1], args...)
+
+# multi-phase versions
+@generated function compute_viscosity(v::NTuple{N, AbstractMaterialParamsStruct}, phase, args) where N
+    quote
+        Base.@_inline_meta
+        Base.@nexprs $N i -> i == phase && (return compute_viscosity(v[i].CompositeRheology[1], args))
+        return 0.0
+    end
+end
+
+# For multi phases given the i-th phase
+@generated function compute_viscosity(v::NTuple{N1, AbstractMaterialParamsStruct}, phase_ratio::Union{NTuple{N1,T}, SVector{N1, T}}, args::Vararg{Any, N2}) where {N1, N2, T}
+    quote
+        Base.@_inline_meta
+        val = 0.0
+        Base.@nexprs $N1 i -> val += compute_viscosity(v[i].CompositeRheology[1], args...) * phase_ratio[i]
+        return val
     end
 end

--- a/test/test_Viscosity.jl
+++ b/test/test_Viscosity.jl
@@ -1,25 +1,61 @@
-using Test, GeoParams
+using Test, GeoParams, StaticArrays
 
 @testset "Viscosity" begin
     εII = 1
-    τII = 1
-    η0 = 1
-    dt = 1
+    τII = 2
+    η0  = 3
+    dt  = 4
     P, T, xx, yy, xy = (rand() for i in 1:5)
     args = (; P=P, T=T, dt=dt)
 
     # Physical properties using GeoParams ----------------
     # create rheology struct
-    el = SetConstantElasticity(; G=1, ν=0.5)
-    creep = LinearViscous(; η=η0)       # Arrhenius-like (T-dependant) viscosity
+    G        = 1
+    el       = SetConstantElasticity(; G=G, ν=0.5)
+    creep    = LinearViscous(; η=η0)
     rheology = SetMaterialParams(; CompositeRheology=CompositeRheology((creep, el)))
 
+    @test compute_viscosity(el, args) == G * dt
+    @test compute_viscosity(creep, args) == η0
+    @test compute_viscosity(rheology, args) == 1/(1 / η0 + 1 / G / dt)
+    
     @test η0 ==
         compute_viscosity_εII(rheology, εII, args) ==
         compute_viscosity_τII(rheology, τII, args)
     @test 1/(1 / η0 + 1 / el.G.val / dt) ==
         compute_elastoviscosity_εII(rheology, εII, args) ==
         compute_elastoviscosity_τII(rheology, τII, args)
+
+    rheologies1 = (
+        SetMaterialParams(; 
+            CompositeRheology=CompositeRheology((LinearViscous(; η=1), ))
+        ),
+        SetMaterialParams(; 
+            CompositeRheology=CompositeRheology((LinearViscous(; η=2), ))
+        )
+    )
+
+    @test compute_viscosity(rheologies1, 1, args) == 1.0
+    @test compute_viscosity(rheologies1, 2, args) == 2.0
+    
+    phase_ratio = (0.5, 0.5)
+    @test compute_viscosity(rheologies1, phase_ratio, args) == 1.5
+    @test compute_viscosity(rheologies1, SA[0.5, 0.5], args) == 1.5
+
+    rheologies2 = (
+        SetMaterialParams(; 
+            CompositeRheology=CompositeRheology((LinearViscous(; η=1), el))
+        ),
+        SetMaterialParams(; 
+            CompositeRheology=CompositeRheology((LinearViscous(; η=2), el))
+        )
+    )
+
+    @test compute_viscosity(rheologies2, 1, args) == 0.8
+    @test compute_viscosity(rheologies2, 2, args) == 1.3333333333333333
+    
+    @test compute_viscosity(rheologies2, phase_ratio, args)  == 1.0666666666666667
+    @test compute_viscosity(rheologies2, SA[0.5, 0.5], args) == 1.0666666666666667
 
     # Slightly more complex example ----------------------
     # function to compute strain rate 
@@ -38,9 +74,7 @@ using Test, GeoParams
     @inline function custom_viscosity(
         a::CustomRheology; P=0.0, T=273.0, depth=0.0, kwargs...
     )
-        η0, Ea, Va, T0, R, cutoff = a.args.η0,
-        a.args.Ea, a.args.Va, a.args.T0, a.args.R,
-        a.args.cutoff
+        (; η0, Ea, Va, T0, R, cutoff) = a.args
         η = η0 * exp((Ea + P * Va) / (R * T) - Ea / (R * T0))
         correction = (depth ≤ 660e3) + (depth > 660e3) * 1e1
         return clamp(η * correction, cutoff...)
@@ -49,7 +83,8 @@ using Test, GeoParams
     # constant parameters, these are typically wrapped into a struct 
     v_args = (; η0=5e20, Ea=200e3, Va=2.6e-6, T0=1.6e3, R=8.3145, cutoff=(1e16, 1e25))
 
-    args = (; depth=1e3, P=1e3 * 3300 * 9.81, T=1.6e3)
+    dt = 100e3 * 3600 * 24 * 365
+    args = (; depth=1e3, P=1e3 * 3300 * 9.81, T=1.6e3, dt = dt)
     τII, εII = 1e3, 1e-15
 
     # create rheology struct

--- a/test/test_Viscosity.jl
+++ b/test/test_Viscosity.jl
@@ -24,7 +24,7 @@ using Test, GeoParams, StaticArrays
     @test η0 ==
         compute_viscosity_εII(rheology, 0.0, args) ==
         compute_viscosity_τII(rheology, 0.0, args)
-    @test 1/(1 / η0 + 1 / el.G.val / dt) ==
+    @test 1/(1 / η0 + 1 / G / dt) ==
         compute_elastoviscosity_εII(rheology, εII, args) ==
         compute_elastoviscosity_τII(rheology, τII, args)
 
@@ -59,9 +59,9 @@ using Test, GeoParams, StaticArrays
     @test compute_viscosity(rheologies2, phase_ratio, args)  == 1.0666666666666667
     @test compute_viscosity(rheologies2, SA[0.5, 0.5], args) == 1.0666666666666667
 
-    @test compute_elasticviscosity(rheologies2, 1, args) == el.G.val * dt
-    @test compute_elasticviscosity(rheologies2, 2, args) == el.G.val * dt
-    @test compute_elasticviscosity(rheologies2, phase_ratio, args) == el.G.val * dt
+    @test compute_elasticviscosity(rheologies2, 1, args) == el.G * dt
+    @test compute_elasticviscosity(rheologies2, 2, args) == el.G * dt
+    @test compute_elasticviscosity(rheologies2, phase_ratio, args) == el.G * dt
     
         # Slightly more complex example ----------------------
     # function to compute strain rate 
@@ -102,7 +102,7 @@ using Test, GeoParams, StaticArrays
     @test η ==
         compute_viscosity_τII(rheology, τII, args) ==
         compute_viscosity_εII(rheology, εII, args)
-    @test 1/(1 / η + 1 / el.G.val / dt) ==
+    @test 1/(1 / η + 1 / el.G / dt) ==
         compute_elastoviscosity_εII(rheology, εII, args) ==
         compute_elastoviscosity_τII(rheology, τII, args)
 end

--- a/test/test_Viscosity.jl
+++ b/test/test_Viscosity.jl
@@ -20,8 +20,8 @@ using Test, GeoParams, StaticArrays
     @test compute_viscosity(rheology, args) == 1/(1 / η0 + 1 / G / dt)
     
     @test η0 ==
-        compute_viscosity_εII(rheology, εII, args) ==
-        compute_viscosity_τII(rheology, τII, args)
+        compute_viscosity_εII(rheology, 0.0, args) ==
+        compute_viscosity_τII(rheology, 0.0, args)
     @test 1/(1 / η0 + 1 / el.G.val / dt) ==
         compute_elastoviscosity_εII(rheology, εII, args) ==
         compute_elastoviscosity_τII(rheology, τII, args)
@@ -57,7 +57,11 @@ using Test, GeoParams, StaticArrays
     @test compute_viscosity(rheologies2, phase_ratio, args)  == 1.0666666666666667
     @test compute_viscosity(rheologies2, SA[0.5, 0.5], args) == 1.0666666666666667
 
-    # Slightly more complex example ----------------------
+    @test compute_elasticviscosity(rheologies2, 1, args) == el.G.val * dt
+    @test compute_elasticviscosity(rheologies2, 2, args) == el.G.val * dt
+    @test compute_elasticviscosity(rheologies2, phase_ratio, args) == el.G.val * dt
+    
+        # Slightly more complex example ----------------------
     # function to compute strain rate 
     @inline function custom_εII(a::CustomRheology, TauII; args...)
         η = custom_viscosity(a; args...)

--- a/test/test_Viscosity.jl
+++ b/test/test_Viscosity.jl
@@ -19,6 +19,8 @@ using Test, GeoParams, StaticArrays
     @test compute_viscosity(creep, args) == η0
     @test compute_viscosity(rheology, args) == 1/(1 / η0 + 1 / G / dt)
     
+    @test_throws "compute_viscosity only works for linear rheologies" compute_viscosity(DislocationCreep(), args)
+
     @test η0 ==
         compute_viscosity_εII(rheology, 0.0, args) ==
         compute_viscosity_τII(rheology, 0.0, args)


### PR DESCRIPTION
Introduces `compute_viscosity` function for `LinearViscous` and `ConstantElasticity` objects:

```julia
η0  = 3
dt  = 4
args = (; dt=dt)
G        = 1
el       = SetConstantElasticity(; G=G, ν=0.5)
creep    = LinearViscous(; η=η0)
rheology = SetMaterialParams(; CompositeRheology=CompositeRheology((creep, el)))

@assert compute_viscosity(el, args) == G * dt  # true
@assert compute_viscosity(creep, args) == η0 # true
@assert compute_viscosity(rheology, args) == 1/(1 / η0 + 1 / G / dt) # true
```

`compute_elasticviscosity` can be used to compute `G * dt`
```julia
rheologies2 = (
    SetMaterialParams(; 
        CompositeRheology=CompositeRheology((LinearViscous(; η=1), el))
    ),
    SetMaterialParams(; 
        CompositeRheology=CompositeRheology((LinearViscous(; η=2), el))
    )
)

@assert compute_elasticviscosity(rheologies2, 1, args) == el.G.val * dt
@assert compute_elasticviscosity(rheologies2, 2, args) == el.G.val * dt
@assert compute_elasticviscosity(rheologies2, phase_ratio, args) == el.G.val * dt
```

All the new functions work with all the GeoParams machinery; more examples in the [tests](https://github.com/JuliaGeodynamics/GeoParams.jl/blob/791abc5bdcb908f296b7ca1e58c25ffd02248690/test/test_Viscosity.jl#L29)

Also fixes the problem when passing zero stress or strain to  `compute_viscosity_εII` and `compute_viscosity_τII`

```julia-repl
julia> compute_viscosity_τII(creep, 0.0, args)
3.0

julia> compute_viscosity_τII(rheology, 0.0, args)
3.0
```