### PR TITLE
Traits

### DIFF
--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -338,6 +338,9 @@ export compute_meltfraction,
     MeltingParam_Assimilation,
     SmoothMelting
 
+include("Traits/rheology.jl")
+export islinear, RheologyTrait, LinearRheology, NonLinearRheology
+
 include("CreepLaw/Data/DislocationCreep.jl")
 using .Dislocation
 

--- a/src/Traits/rheology.jl
+++ b/src/Traits/rheology.jl
@@ -1,0 +1,23 @@
+abstract type RheologyTrait end
+struct LinearRheology <: RheologyTrait end
+struct NonLinearRheology <: RheologyTrait end
+
+# traits individual rheologies
+islinear(::AbstractElasticity)      = LinearRheology()
+islinear(::LinearViscous)           = LinearRheology()
+islinear(::AbstractConstitutiveLaw) = NonLinearRheology()
+islinear(::T) where T               = throw(ArgumentError("$T is an unsupported rheology type"))
+
+# compares two rheologies and return linear trait only and if only both are linear
+islinear(::LinearRheology, ::LinearRheology) = LinearRheology()
+islinear(::RheologyTrait, ::RheologyTrait) = NonLinearRheology()
+islinear(v1::AbstractConstitutiveLaw, v2::AbstractConstitutiveLaw) = islinear(islinear(v1), islinear(v2))
+
+# traits for composite rheologies
+islinear(c::CompositeRheology) = islinear(c.elements)
+# traits for MaterialParams
+islinear(r::MaterialParams) = islinear(r.CompositeRheology...)
+
+# recursively (pairwise, right-to-left) compare rheology traits of a composite or tuple of material params
+islinear(r::NTuple{N, Union{AbstractConstitutiveLaw, MaterialParams}}) where N = islinear(islinear(r[1]), islinear(Base.tail(r)))    
+islinear(v::NTuple{1, Union{AbstractConstitutiveLaw, MaterialParams}}) = islinear(v[1])

--- a/test/test_Traits.jl
+++ b/test/test_Traits.jl
@@ -1,0 +1,58 @@
+using Test, GeoParams
+
+@testset "Traits" begin
+    # Define a range of rheological components
+    v1 = DiffusionCreep()
+    v2 = DislocationCreep()
+    v3 = LinearViscous()
+    el = ConstantElasticity()           # elasticity
+    pl = DruckerPrager()        # plasticity which ends up with the same yield stress as pl3
+    # CompositeRheologies
+    c = CompositeRheology(v1, v2, v3)
+    r1 = (
+        SetMaterialParams(;
+            CompositeRheology = CompositeRheology(v1, v2, v3),
+        ),
+        SetMaterialParams(;
+            CompositeRheology = CompositeRheology(el, v3),
+        ),
+    )
+    r2 = (
+        SetMaterialParams(;
+            CompositeRheology = CompositeRheology(el, v3),
+        ),
+        SetMaterialParams(;
+            CompositeRheology = CompositeRheology(el, v3),
+        ),
+    )
+
+    # test basic cases
+    for r in (v1, v2, pl)
+        @test islinear(r) isa NonLinearRheology
+    end
+    for r in (v3, el)
+        @test islinear(r) isa LinearRheology
+    end
+    @test_throws ArgumentError islinear("potato")
+
+    # test composite cases
+    @test islinear(v1, v2) isa NonLinearRheology
+    @test islinear(v1, v3) isa NonLinearRheology
+    @test islinear(v3, el) isa LinearRheology
+
+    @test islinear(tuple(v1, v2)) isa NonLinearRheology
+    @test islinear(tuple(v1, v3)) isa NonLinearRheology
+    @test islinear(tuple(v3, el)) isa LinearRheology
+
+    @test islinear(CompositeRheology(v1, v2, v3)) isa NonLinearRheology
+    @test islinear(CompositeRheology(el, v3)) isa LinearRheology
+
+    # test MaterialParams cases
+    @test islinear(r1[1]) isa NonLinearRheology
+    @test islinear(r1[2]) isa LinearRheology
+    @test islinear(r1)    isa NonLinearRheology
+
+    @test islinear(r2[1]) isa LinearRheology
+    @test islinear(r2[2]) isa LinearRheology
+    @test islinear(r2)    isa LinearRheology
+end


### PR DESCRIPTION
Adds traits based on the so-called [Holy Traits](https://ahsmart.com/pub/holy-traits-design-patterns-and-best-practice-book/). Example a non/linear trait for the creep laws:

```julia
# traits individual rheologies
@inline islinear(::AbstractElasticity)      = LinearRheology()
@inline islinear(::LinearViscous)           = LinearRheology()
@inline islinear(::AbstractConstitutiveLaw) = NonLinearRheology()
@inline islinear(::T) where T               = throw(ArgumentError("$T is an unsupported rheology type"))

# compares two rheologies and return linear trait only and if only both are linear
@inline islinear(::LinearRheology, ::LinearRheology) = LinearRheology()
@inline islinear(::RheologyTrait, ::RheologyTrait) = NonLinearRheology()
@inline islinear(v1::AbstractConstitutiveLaw, v2::AbstractConstitutiveLaw) = islinear(islinear(v1), islinear(v2))

# traits for composite rheologies
@inline islinear(c::CompositeRheology) = islinear(c.elements)
# traits for MaterialParams
@inline islinear(r::MaterialParams) = islinear(r.CompositeRheology...)

# recursively (pairwise, right-to-left) compare rheology traits of a composite or tuple of material params
@inline islinear(r::NTuple{N, Union{AbstractConstitutiveLaw, MaterialParams}}) where N = islinear(islinear(first(r)), islinear(Base.tail(r)))    
@inline islinear(v::NTuple{1, Union{AbstractConstitutiveLaw, MaterialParams}}) = islinear(v...)
```

Now if I have a rheology such as
```julia
    r = (
        SetMaterialParams(;
            CompositeRheology = CompositeRheology(ConstantElasticity(), LinearViscous()),
        ),
    )
 ```
I can check that in fact the rheology of `r` is indeed linear:
```julia-repl
julia> islinear(r)
LinearRheology()
```
And this is all done at compile time:
```julia-repl
julia> using Chairmarks
julia> @b islinear($r)
0 ns
julia> @code_typed optimize=true islinear(r)
CodeInfo(
1 ─     return $(QuoteNode(LinearRheology()))
) => LinearRheology
```

All this is useful because, for example, now in my PT solver I could do something like
```julia
compute_viscosity(rheology, args) = compute_viscosity(islinear(rheology), args)
compute_viscosity(::LinearRheology, args)  = nothing # viscosity doesn't need to be updated within PT iterations
function compute_viscosity(::NonLinearRheology, args) # viscosity needs to be updated within PT iterations
   # compute viscosity
end
```
so that the decision of whether updating or not the viscosity within the PT iterations is branchless and given by the type system in a simple way to the user. 

I will extend this to other parts of GeoParams where it could be useful, e.g. to check whether density is constant or not, if i need plasticity stress corrections, etc...

