### PR TITLE
Increase compatibility with AD tools

### DIFF
--- a/src/CompositeRheologies/NonlinearIterations.jl
+++ b/src/CompositeRheologies/NonlinearIterations.jl
@@ -23,6 +23,7 @@ function local_iterations_εII(
     iter = 0
     ϵ = 2.0 * tol
     τII_prev = τII
+    
     while ϵ > tol
         iter += 1
         #= 
@@ -33,12 +34,15 @@ function local_iterations_εII(
                 τII -= f / dfdτII
         =#
         τII = @muladd τII + (εII - compute_εII(v, τII, args)) * inv(dεII_dτII(v, τII, args)) 
-
         ϵ = abs(τII - τII_prev) * inv(τII)
         τII_prev = τII
-
         # @print(verbose, " iter $(iter) $ϵ")
+        
+        T_check = ϵ isa Union{AbstractFloat,Integer}
+        !(T_check) && break
+        (ϵ > tol) && break
     end
+   
     # @print(verbose, "final τII = $τII")
     # @print(verbose, "---")
 

--- a/src/CompositeRheologies/NonlinearIterations.jl
+++ b/src/CompositeRheologies/NonlinearIterations.jl
@@ -40,7 +40,6 @@ function local_iterations_εII(
         
         T_check = ϵ isa Union{AbstractFloat,Integer}
         !(T_check) && break
-        (ϵ > tol) && break
     end
    
     # @print(verbose, "final τII = $τII")

--- a/src/Plasticity/DruckerPrager.jl
+++ b/src/Plasticity/DruckerPrager.jl
@@ -78,7 +78,7 @@ function (s::DruckerPrager{_T, U, U1, NoSoftening, S})(;
 end
 
 function (s::DruckerPrager{_T, U, U1, S, NoSoftening})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), EII=zero(_T), kwargs...
 ) where {_T,U,U1,S}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
     ϕ = s.softening_ϕ(EII, ϕ)
@@ -90,7 +90,7 @@ function (s::DruckerPrager{_T, U, U1, S, NoSoftening})(;
 end
 
 function (s::DruckerPrager{_T, U, U1, NoSoftening, NoSoftening})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), kwargs...
 ) where {_T,U,U1}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
 
@@ -104,7 +104,7 @@ end
 Computes the plastic yield function `F` for a given second invariant of the deviatoric stress tensor `τII`,  `P` pressure, and `Pf` fluid pressure.
 """
 function compute_yieldfunction(
-    s::DruckerPrager{_T}; P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), EII::_T=zero(_T)
+    s::DruckerPrager{_T}; P=zero(_T), τII=zero(_T), Pf=zero(_T), EII=zero(_T)
 ) where {_T}
     return s(; P=P, τII=τII, Pf=Pf, EII=EII)
 end

--- a/src/Plasticity/DruckerPrager.jl
+++ b/src/Plasticity/DruckerPrager.jl
@@ -55,7 +55,7 @@ end
 
 # Calculation routines
 function (s::DruckerPrager{_T, U, U1, S, S})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), EII=zero(_T), kwargs...
 ) where {_T,U,U1,S<:AbstractSoftening}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
     ϕ = s.softening_ϕ(EII, ϕ)
@@ -68,7 +68,7 @@ function (s::DruckerPrager{_T, U, U1, S, S})(;
 end
 
 function (s::DruckerPrager{_T, U, U1, NoSoftening, S})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), EII=zero(_T), kwargs...
 ) where {_T,U,U1,S}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
     C = s.softening_C(EII, C)

--- a/src/Plasticity/DruckerPrager_regularised.jl
+++ b/src/Plasticity/DruckerPrager_regularised.jl
@@ -56,7 +56,7 @@ end
 
 # Calculation routines
 function (s::DruckerPrager_regularised{_T})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), λ::_T= zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), λ= zero(_T), EII=zero(_T), kwargs...
 ) where {_T}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     ϕ = s.softening_ϕ(EII, ϕ)
@@ -68,7 +68,7 @@ function (s::DruckerPrager_regularised{_T})(;
 end
 
 function (s::DruckerPrager_regularised{_T,U,U1,NoSoftening, S})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), λ::_T= zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), λ= zero(_T), EII=zero(_T), kwargs...
 ) where {_T,U,U1,S}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     C = s.softening_C(EII, C)
@@ -78,7 +78,7 @@ function (s::DruckerPrager_regularised{_T,U,U1,NoSoftening, S})(;
 end
 
 function (s::DruckerPrager_regularised{_T,U,U1,S, NoSoftening})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), λ::_T= zero(_T), EII::_T=zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), λ= zero(_T), EII=zero(_T), kwargs...
 ) where {_T,U,U1,S}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     ϕ = s.softening_ϕ(EII, ϕ)
@@ -89,7 +89,7 @@ function (s::DruckerPrager_regularised{_T,U,U1,S, NoSoftening})(;
 end
 
 function (s::DruckerPrager_regularised{_T,U,U1,NoSoftening,NoSoftening})(;
-    P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), λ::_T= zero(_T), kwargs...
+    P=zero(_T), τII=zero(_T), Pf=zero(_T), λ= zero(_T), kwargs...
 ) where {_T,U,U1}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     ε̇II_pl = λ*∂Q∂τII(s, τII)  # plastic strainrate
@@ -105,7 +105,7 @@ end
 Computes the plastic yield function `F` for a given second invariant of the deviatoric stress tensor `τII`,  `P` pressure, and `Pf` fluid pressure.
 """
 function compute_yieldfunction(
-    s::DruckerPrager_regularised{_T}; P::_T=zero(_T), τII::_T=zero(_T), Pf::_T=zero(_T), λ::_T=zero(_T), EII::_T=zero(_T)
+    s::DruckerPrager_regularised{_T}; P=zero(_T), τII=zero(_T), Pf=zero(_T), λ=zero(_T), EII=zero(_T)
 ) where {_T}
     return s(; P=P, τII=τII, Pf=Pf, λ=λ, EII=EII)
 end


### PR DESCRIPTION
Makes stress local iteration methods, as well as `DruckerPrager` and `DruckerPrager_regularised` compatible with, at least, `ForwardDiff.jl`