### PR TITLE
fix `compute_meltfraction`

### DIFF
--- a/src/Energy/Shearheating.jl
+++ b/src/Energy/Shearheating.jl
@@ -172,7 +172,7 @@ end
 
 function compute_shearheating(s::AbstractMaterialParamsStruct, args::Vararg{Any,N}) where N
     if isempty(s.ShearHeat)
-        return 0.0  # return zero if not specified
+        return 0e0  # return zero if not specified
     else
         return compute_shearheating(s.ShearHeat[1], args...)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return isempty(args) ? 0.0 : zero(typeof(args).types[1])  # return zero if not specified
+        return 0.0 # return zero if not specified
     else
         return compute_meltfraction(s.Melting[1], args)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return zero(typeof(args)) # return zero if not specified
+        return 0.0 # return zero if not specified
     else
         return compute_meltfraction(s.Melting[1], args)
     end
@@ -755,7 +755,7 @@ end
 
 function compute_dϕdT(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return zero(typeof(args).types[1])
+        return 0.0 # return zero if not specified
     else
         return compute_dϕdT(s.Melting[1], args)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return zero(typeof(args).types[1])
+        return isempty(args) ? 0.0 : zero(typeof(args).types[1])  # return zero if not specified
     else
         return compute_meltfraction(s.Melting[1], args)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return 0.0 # return zero if not specified
+        return 0e0 # return zero if not specified
     else
         return compute_meltfraction(s.Melting[1], args)
     end
@@ -755,7 +755,7 @@ end
 
 function compute_dϕdT(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return 0.0 # return zero if not specified
+        return 0e0 # return zero if not specified
     else
         return compute_dϕdT(s.Melting[1], args)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return 0.0 # return zero if not specified
+        return zero(typeof(args)) # return zero if not specified
     else
         return compute_meltfraction(s.Melting[1], args)
     end


### PR DESCRIPTION
fixes an issue with `compute_meltfraction` reported in JustRelax when running on the GPU. if `s.Melting` is empty it now returns `0e0` and not `zero(eltype(args).type[1])` anymore. 

- also updated number format for Shearheating (where we alreadt did the same as in melting)