### PR TITLE
Add power law strain/stress functions

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -69,7 +69,7 @@ export param_info,
 # add methods programmatically 
 for myType in (:LinearViscous, :LinearMeltViscosity, :ViscosityPartialMelt_Costa_etal_2009, 
                 :DiffusionCreep, :DislocationCreep, :ConstantElasticity, :DruckerPrager, :ArrheniusType, 
-                :GrainBoundarySliding, :PeierlsCreep, :NonLinearPeierlsCreep)
+                :GrainBoundarySliding, :PeierlsCreep, :NonLinearPeierlsCreep, :PowerlawViscous)
     @eval begin
         @inline compute_εII(a::$(myType), TauII, args) = compute_εII(a, TauII; args...)
         @inline compute_εvol(a::$(myType), P, args) = compute_εvol(a, P; args...)

--- a/src/CreepLaw/CreepLaw.jl
+++ b/src/CreepLaw/CreepLaw.jl
@@ -194,7 +194,7 @@ or
 where ``\\eta_0`` is the reference viscosity [Pa*s] at reference strain rate ``\\dot{\\varepsilon}_0``[1/s], and ``n`` the power law exponent []. 
 """
 @with_kw_noshow struct ArrheniusType{_T,U1,U2,U3} <: AbstractCreepLaw{_T}
-    η_0::GeoUnit{_T,U1} = 1.0NoUnits      # Pre-exponential factor
+    η0::GeoUnit{_T,U1} = 1.0NoUnits      # Pre-exponential factor
     E_η::GeoUnit{_T,U2} = 23.03NoUnits    # Activation energy (non-dimensional)
     T_O::GeoUnit{_T,U3} = 1.0NoUnits      # Offset temperature 
     T_η::GeoUnit{_T,U3} = 1.0NoUnits      # Reference temperature at which viscosity is unity
@@ -215,10 +215,11 @@ function param_info(a::ArrheniusType) # info about the struct
         Equation=L"\tau_{ij} = 2 \eta_0 exp( E_η/(T + T_O) + E_η/(T_η + T_O))  \dot{\varepsilon}_{ij}",
     )
 end
+
 # Calculation routines for linear viscous rheologies
 function compute_εII(a::ArrheniusType, TauII; T=one(precision(a)), kwargs...)
-    @unpack_val η_0, E_η, T_O, T_η = a
-    η = η_0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
+    @unpack_val η0, E_η, T_O, T_η = a
+    η = η0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
     return (TauII / η) * 0.5
 end
 
@@ -241,8 +242,8 @@ function compute_εII!(
 end
 
 function dεII_dτII(a::ArrheniusType, TauII; T=one(precision(a)), kwargs...)
-    @unpack_val η_0, E_η, T_O, T_η = a
-    η = η_0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
+    @unpack_val η0, E_η, T_O, T_η = a
+    η = η0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
     return 0.5 * inv(η)
 end
 
@@ -252,9 +253,9 @@ end
 Returns second invariant of the stress tensor given a 2nd invariant of strain rate tensor 
 """
 function compute_τII(a::ArrheniusType, EpsII; T=one(precision(a)), kwargs...)
-    @unpack_val η_0, E_η, T_O, T_η = a
+    @unpack_val η0, E_η, T_O, T_η = a
 
-    η = η_0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
+    η = η0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
 
     return 2 * (η * EpsII)
 end
@@ -274,8 +275,8 @@ function compute_τII!(
 end
 
 function dτII_dεII(a::ArrheniusType, EpsII; T=one(precision(a)), kwargs...)
-    @unpack_val η_0, E_η, T_O, T_η = a
-    η = η_0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
+    @unpack_val η0, E_η, T_O, T_η = a
+    η = η0 * exp(E_η / (T + T_O) - E_η / (T_η + T_O))
 
     return 2 * η
 end
@@ -284,7 +285,7 @@ end
 function show(io::IO, g::ArrheniusType)
     return print(
         io,
-        "ArrheniusType: η_0 = $(Value(g.η_0)), E_η = $(Value(g.E_η)), T_O = $(Value(g.T_O)), T_η = $(Value(g.T_η))",
+        "ArrheniusType: η0 = $(Value(g.η0)), E_η = $(Value(g.E_η)), T_O = $(Value(g.T_O)), T_η = $(Value(g.T_η))",
     )
 end
 
@@ -300,9 +301,9 @@ Defines a power law viscous creeplaw as:
 where ``\\eta`` is the effective viscosity [Pa*s].
 """
 @with_kw_noshow struct PowerlawViscous{T,U1,U2,U3} <: AbstractCreepLaw{T}
-    η0::GeoUnit{T,U1} = 1e18Pa * s            # reference viscosity 
-    n::GeoUnit{T,U2} = 2.0 * NoUnits         # powerlaw exponent
-    ε0::GeoUnit{T,U3} = 1e-15 * 1 / s          # reference strainrate
+    η0::GeoUnit{T,U1} = 1e18Pa * s       # reference viscosity 
+    n::GeoUnit{T,U2} = 2.0 * NoUnits     # powerlaw exponent
+    ε0::GeoUnit{T,U3} = 1e-15/s          # reference strainrate
 end
 PowerlawViscous(a...) = PowerlawViscous(convert.(GeoUnit, a)...)
 
@@ -310,23 +311,41 @@ PowerlawViscous(a...) = PowerlawViscous(convert.(GeoUnit, a)...)
 function show(io::IO, g::PowerlawViscous)
     return print(io, "Powerlaw viscosity: η0=$(g.η0.val), n=$(g.n.val), ε0=$(g.ε0.val) ")
 end
-#-------------------------------------------------------------------------
 
-#=
-# add methods programmatically 
-#for myType in (:LinearViscous, :DiffusionCreep, :DislocationCreep, :ConstantElasticity)
-for myType in (:LinearViscous, :DiffusionCreep, :DislocationCreep)
+# Calculation routines for linear viscous rheologies
+function compute_εII(a::PowerlawViscous, TauII; kwargs...)
+    @unpack_val η0, n, ε0 = a
 
-    @eval begin
-        compute_εII(TauII, a::$(myType), args) = compute_εII(TauII, a; args...) 
-        dεII_dτII(TauII, a::$(myType), args) = dεII_dτII(TauII, a; args...) 
-        compute_τII(EpsII, a::$(myType), args) = compute_τII(EpsII, a; args...) 
-        if Symbol($myType) !== :ConstantElasticity
-            dτII_dεII(EpsII, a::$(myType), args) = dτII_dεII(EpsII, a; args...)
-        end
-    end
+    @pow EpsII = (TauII / η0)^(1/n) * ε0
+    
+    return EpsII
 end
-=#
+
+function dεII_dτII(a::PowerlawViscous, TauII; kwargs...)
+    @unpack_val η0, n, ε0 = a
+
+    return @pow ((TauII^((1 - n) / n))*(1^(1 / n))) / (n*(η0^(1 / n)))
+end
+
+"""
+    compute_τII(s::PowerlawViscous, EpsII; kwargs...)
+
+Returns second invariant of the stress tensor given a 2nd invariant of strain rate tensor 
+"""
+function compute_τII(a::PowerlawViscous, EpsII; kwargs...)
+    @unpack_val η0, n, ε0 = a
+
+    τII  = @pow ε0 * η0 * (EpsII / ε0)^n
+
+    return τII
+end
+
+function dτII_dεII(a::PowerlawViscous, EpsII; kwargs...)
+    @unpack_val η0, n, ε0 = a
+
+    return @pow η0 * EpsII^(n - 1) * (1 / ε0)^n
+end
+#-------------------------------------------------------------------------
 
 # Help info for the calculation routines
 """

--- a/src/CreepLaw/CreepLaw.jl
+++ b/src/CreepLaw/CreepLaw.jl
@@ -324,7 +324,7 @@ end
 function dεII_dτII(a::PowerlawViscous, TauII; kwargs...)
     @unpack_val η0, n, ε0 = a
 
-    return @pow ((TauII^((1 - n) / n))*(1^(1 / n))) / (n*(η0^(1 / n)))
+    return @pow (TauII^((1 - n) / n)) / (n*(η0^(1 / n)))
 end
 
 """

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -738,8 +738,8 @@ for myType in (
     :SmoothMelting,
 )
     @eval begin
-        (p::$(myType))(args) = p(; args...)
-        compute_meltfraction(p::$(myType), args) = p(; args...)
+        (p::$(myType))(args) = clamp(p(; args...), one(eltype(args)), zero(eltype(args)))
+        compute_meltfraction(p::$(myType), args) = clamp(p(; args...), one(eltype(args)), zero(eltype(args)))
         compute_dϕdT(p::$(myType), args) = compute_dϕdT(p; args...)
     end
 end
@@ -747,7 +747,7 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_meltfraction(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return zero(typeof(args).types[1])
+        return zero(eltype(args))
     else
         return compute_meltfraction(s.Melting[1], args)
     end
@@ -755,7 +755,7 @@ end
 
 function compute_dϕdT(s::AbstractMaterialParamsStruct, args)
     if isempty(s.Melting) #in case there is a phase with no melting parametrization
-        return zero(typeof(args).types[1])
+        return zero(eltype(args))
     else
         return compute_dϕdT(s.Melting[1], args)
     end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -581,7 +581,7 @@ julia> T,phi,dϕdT =  PlotMeltFraction(p,T=T);
 The same but with smoothening:
 ```julia
 julia> p_s = SmoothMelting(p=MeltingParam_4thOrder(), k_liq=0.21/K);
-4th order polynomial melting curve: phi = -7.594512597174117e-10T^4 + 3.469192091489447e-6T^3 + -0.00592352980926T^2 + 4.482855645604745T + -1268.730161921053  963.15 K ≤ T ≤ 1270.15 K with smooth Heaviside function smoothening using k_sol=0.1 K⁻¹·⁰, k_liq=0.11 K⁻¹·⁰
+4th order polynomial melting curve: phi = -7.594512597174117e-10T^4 + 3.469192091489447e-6T^3 + -0.00592352980926T^2 + 4.482855645604745T + -1268.730161921053  963.15 K ≤ T ≤ 1270.15 K with smooth Heaviside function smoothening using k_sol=0.1 K⁻¹·⁰, k_liq=0.11 K⁻¹·⁰
 julia> T_s,phi_s,dϕdT_s =  PlotMeltFraction(p_s,T=T);
 ```
 
@@ -738,8 +738,8 @@ for myType in (
     :SmoothMelting,
 )
     @eval begin
-        (p::$(myType))(args) = clamp(p(; args...), one(eltype(args)), zero(eltype(args)))
-        compute_meltfraction(p::$(myType), args) = clamp(p(; args...), one(eltype(args)), zero(eltype(args)))
+        (p::$(myType))(args) = p(; args...)
+        compute_meltfraction(p::$(myType), args) = p(; args...)
         compute_dϕdT(p::$(myType), args) = compute_dϕdT(p; args...)
     end
 end
@@ -767,7 +767,7 @@ end
 Computation of melt fraction ϕ for the whole domain and all phases, in case an array with phase properties `MatParam` is provided, along with `P` and `T` arrays.
 """
 compute_meltfraction(args::Vararg{Any,N}) where {N} =
-    clamp(compute_param(compute_meltfraction, args...), 0e0, 1e0)
+    clamp(compute_param(compute_meltfraction, args...), 0, 1)
 
 """
     compute_meltfraction(ϕ::AbstractArray{<:AbstractFloat}, Phases::AbstractArray{<:Integer}, P::AbstractArray{<:AbstractFloat},T::AbstractArray{<:AbstractFloat}, MatParam::AbstractArray{<:AbstractMaterialParamsStruct})

--- a/test/test_CreepLaw.jl
+++ b/test/test_CreepLaw.jl
@@ -1,6 +1,7 @@
 using Test, Statistics
 using GeoParams
 
+
 @testset "CreepLaw" begin
 
     #Make sure structs are isbits
@@ -29,7 +30,7 @@ using GeoParams
 
     x1_ND = LinearViscous(; η=1e18Pa * s)
     @test isDimensional(x1_ND) == true
-    x1_ND = nondimensionalize(x1_ND, CharUnits_GEO)                 # check that we can nondimensionalize all entries within the struct
+    x1_ND = nondimensionalize(x1_ND, CharUnits_GEO)                # check that we can nondimensionalize all entries within the struct
     @test isDimensional(x1_ND) == false
     @test x1_ND.η * 1.0 == 0.1
     x1_D = dimensionalize(x1_ND, CharUnits_GEO)                    # check that we can dimensionalize it again
@@ -53,11 +54,23 @@ using GeoParams
     ε = [0.0; 0.0]
     compute_τII!(ε, x1_ND, [1e0; 2.0], args)
     @test ε == [0.2; 0.4]     # vector input
-
     # -------------------------------------------------------------------
 
     # -------------------------------------------------------------------
     # Define powerlaw viscous rheology
+    η0 = 10
+    n  = 2.3
+    ε0 = 1
+    x2 = PowerlawViscous(; η0 = 10, n=2.3, ε0 = 1)
+
+    τII = 1e0
+    εII = 1e0
+    @test compute_τII(x2, τII) == η0
+    @test compute_εII(x2, εII) == 0.36746619407366893
+
+    @test compute_viscosity_εII(x2, τII, (;)) == 5e0
+    @test compute_viscosity_τII(x2, εII, (;)) == 1.3606693841876538
+
     x2 = PowerlawViscous()
     x2 = nondimensionalize(x2, CharUnits_GEO)
     @test NumValue(x2.ε0) == 0.001                                 # powerlaw
@@ -269,3 +282,4 @@ using GeoParams
 
 
 end
+

--- a/test/test_CreepLaw.jl
+++ b/test/test_CreepLaw.jl
@@ -247,7 +247,7 @@ using GeoParams
         η_rhyolite[i] = compute_viscosity_εII(x_rhyolite, εII, (; ϕ=ϕ_rhyolite[i], T=T[i]))
 
     end
-    @test mean(η_rhyolite) ≈ 1.262261299272795e19Pas
+    @test mean(η_rhyolite) ≈ 1.2614388007523279e19Pas
     @test mean(η_basalt)   ≈ 5.822731206904198e24Pas
     @test mean(η_basalt1)  ≈ 8.638313729394237e21Pas
 


### PR DESCRIPTION
Power law creep had a `struct` already defined in `src/CreepLaw.jl`. However, there were no methods associated to it.