### PR TITLE
Add `DippingGravity` type

### DIFF
--- a/docs/src/man/gravity.md
+++ b/docs/src/man/gravity.md
@@ -4,6 +4,7 @@
 Gravitational acceleration is defined as 
 ```@docs
 GeoParams.MaterialParameters.GravitationalAcceleration.ConstantGravity
+GeoParams.MaterialParameters.GravitationalAcceleration.DippingGravity
 ```
 
 ## Computational routines

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -265,7 +265,8 @@ export compute_viscosity_εII,
 # Gravitational Acceleration
 using .MaterialParameters.GravitationalAcceleration
 export compute_gravity,                                # computational routines
-    ConstantGravity
+    ConstantGravity,
+    DippingGravity
 
 # Energy parameters: Heat Capacity, Thermal conductivity, latent heat, radioactive heat
 using .MaterialParameters.HeatCapacity

--- a/src/GravitationalAcceleration/GravitationalAcceleration.jl
+++ b/src/GravitationalAcceleration/GravitationalAcceleration.jl
@@ -2,7 +2,7 @@ module GravitationalAcceleration
 
 # This implements the gravitational acceleration
 
-using Parameters, LaTeXStrings, Unitful
+using Parameters, LaTeXStrings, Unitful, StaticArrays
 using ..Units
 using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
 import Base.show, GeoParams.param_info
@@ -10,8 +10,9 @@ using ..MaterialParameters: MaterialParamsInfo
 
 abstract type AbstractGravity{_T} <: AbstractMaterialParam end
 
-export compute_gravity,        # calculation routines
-    ConstantGravity,        # constant
+export compute_gravity, # calculation routines
+    ConstantGravity,    # constant
+    DippingGravity,     # constant with dip and strike angles
     param_info
 
 # Constant Gravity -------------------------------------------------------
@@ -39,11 +40,77 @@ function compute_gravity(s::ConstantGravity)
     return g
 end
 
+# Print info 
+function show(io::IO, d::ConstantGravity)
+    return print(io, "Gravitational acceleration: g=$(UnitValue(d.g))")
+end
+#-------------------------------------------------------------------------
+
+# Constant Gravity -------------------------------------------------------
+"""
+    DippingGravity(g=9.81m/s^2)
+    
+Set a constant value for the gravitational acceleration with dip and strike angles:
+```math  
+    g  = R_z  R_y  9.81 m s^{-2} 
+```
+"""
+@kwdef struct DippingGravity{_T,U} #<: AbstractGravity{_T}
+    g::GeoUnit{_T,U}  = 9.81m / s^2 # gravitational acceleration
+    gx::GeoUnit{_T,U} = 0e0m / s^2  # gravitational acceleration
+    gy::GeoUnit{_T,U} = 0e0m / s^2  # gravitational acceleration
+    gz::GeoUnit{_T,U} = 9.81m / s^2 # gravitational acceleration
+end
+DippingGravity(args...) = DippingGravity(convert.(GeoUnit, args)...)
+
+function DippingGravity(α, θ, g::T) where T
+    sinα, cosα = sincosd(90 - α)
+    sinθ, cosθ = sincosd(θ)
+    gᵢ         = @SVector [zero(T), zero(T), g]
+
+    Ry = @SMatrix [
+        cosα    zero(T) sinα
+        zero(T)  one(T) zero(T)
+       -sinα    zero(T) cosα
+    ]
+
+    Rz = @SMatrix [
+        cosθ    -sinθ   zero(T)
+        sinθ    cosθ    zero(T)
+        zero(T) zero(T) one(T)
+    ]
+    g′ = Rz * (Ry * gᵢ)
+
+    return DippingGravity(; g=g, gx = g′[1], gy = g′[2], gz = g′[3])
+end
+
+function param_info(s::DippingGravity) # info about the struct
+    return MaterialParamsInfo(; Equation=L"g = ($(s.gx, s.gy, s.gz)) m s^{-2}")
+end
+
 # Calculation routine
-@inline @generated function compute_gravity(
+function compute_gravity(s::DippingGravity)
+    @unpack_val gx, gy, gz = s
+    return gx, gy, gz
+end
+
+# Print info 
+function show(io::IO, d::DippingGravity)
+    return print(io, "Gravitational acceleration: g=$((UnitValue(d.gz), UnitValue(d.gy), UnitValue(d.gz)))")
+end
+
+function show(io::IO, ::Any, d::DippingGravity)
+    return print(io, "Gravitational acceleration: g=$((UnitValue(d.gz), UnitValue(d.gy), UnitValue(d.gz)))")
+end
+#-------------------------------------------------------------------------
+
+
+# Calculation routine
+@generated function compute_gravity(
     MatParam::NTuple{N,AbstractMaterialParamsStruct}, Phase::Integer
 ) where {N}
     quote
+        @inline 
         Base.Cartesian.@nexprs $N i ->
             (MatParam[i].Phase == Phase) && return compute_gravity(MatParam[i].Gravity[1])
     end
@@ -51,11 +118,6 @@ end
 
 compute_gravity(MatParam::AbstractMaterialParamsStruct) = compute_gravity(MatParam.Gravity[1])
 
-# Print info 
-function show(io::IO, d::ConstantGravity)
-    return print(io, "Gravitational acceleration: g=$(UnitValue(d.g))")
-end
-#-------------------------------------------------------------------------
 
 # Help info for the calculation routines
 """

--- a/test/test_Gravity.jl
+++ b/test/test_Gravity.jl
@@ -1,0 +1,24 @@
+using Test, GeoParams
+
+@testset "Gravity" begin
+
+    g = 9.81
+
+    gconst = ConstantGravity()
+    @test gconst.g == convert(GeoUnit, 9.81m / s^2)
+
+    gconst = ConstantGravity(; g = 1)
+    @test gconst.g == convert(GeoUnit,1)
+
+    d = DippingGravity(90, 0, g)
+    gᵢ = compute_gravity2(d)
+    @test gᵢ == (0e0, 0e0, g)
+
+    d = DippingGravity(45, 0, g)
+    gᵢ = compute_gravity2(d)
+    @test gᵢ == sind(90 - α) .* (g, 0, g)
+
+    d = DippingGravity(45, 45, g)
+    gᵢ = compute_gravity2(d)
+    @test gᵢ ==   sind(90 - α) .* (g *  cosd(45), g *  cosd(45), g)
+end

--- a/test/test_Gravity.jl
+++ b/test/test_Gravity.jl
@@ -11,14 +11,14 @@ using Test, GeoParams
     @test gconst.g == convert(GeoUnit,1)
 
     d = DippingGravity(90, 0, g)
-    gᵢ = compute_gravity2(d)
+    gᵢ = compute_gravity(d)
     @test gᵢ == (0e0, 0e0, g)
 
     d = DippingGravity(45, 0, g)
-    gᵢ = compute_gravity2(d)
+    gᵢ = compute_gravity(d)
     @test gᵢ == sind(90 - α) .* (g, 0, g)
 
     d = DippingGravity(45, 45, g)
-    gᵢ = compute_gravity2(d)
+    gᵢ = compute_gravity(d)
     @test gᵢ ==   sind(90 - α) .* (g *  cosd(45), g *  cosd(45), g)
 end

--- a/test/test_Gravity.jl
+++ b/test/test_Gravity.jl
@@ -5,20 +5,21 @@ using Test, GeoParams
     g = 9.81
 
     gconst = ConstantGravity()
-    @test gconst.g == convert(GeoUnit, 9.81m / s^2)
+    @test compute_gravity(gconst) == 9.81
 
     gconst = ConstantGravity(; g = 1)
-    @test gconst.g == convert(GeoUnit,1)
+    @test compute_gravity(gconst) == 1
 
     d = DippingGravity(90, 0, g)
     gᵢ = compute_gravity(d)
     @test gᵢ == (0e0, 0e0, g)
 
-    d = DippingGravity(45, 0, g)
+    α = 45
+    d = DippingGravity(α, 0, g)
     gᵢ = compute_gravity(d)
     @test gᵢ == sind(90 - α) .* (g, 0, g)
 
-    d = DippingGravity(45, 45, g)
+    d = DippingGravity(α, α, g)
     gᵢ = compute_gravity(d)
     @test gᵢ ==   sind(90 - α) .* (g *  cosd(45), g *  cosd(45), g)
 end


### PR DESCRIPTION
Adds a gravity field in a rotated Cartesian frame of reference. It may be useful for, e.g., modelling subduction channels.