### PR TITLE
Conduit densities

### DIFF
--- a/docs/src/man/density.md
+++ b/docs/src/man/density.md
@@ -1,4 +1,4 @@
-# Density 
+# Density
 
 ## Methods
 The density equation of state can be specified in a number of ways
@@ -8,6 +8,8 @@ GeoParams.MaterialParameters.Density.PT_Density
 GeoParams.MaterialParameters.Density.T_Density
 GeoParams.MaterialParameters.Density.Compressible_Density
 GeoParams.MaterialParameters.Density.MeltDependent_Density
+GeoParams.MaterialParameters.Density.BubbleFlow_Density
+GeoParams.MaterialParameters.Density.GasPyroclast_Density
 ```
 ## Computational routines
 To evaluate density within a user routine, use this:
@@ -15,4 +17,4 @@ To evaluate density within a user routine, use this:
 GeoParams.MaterialParameters.Density.compute_density
 GeoParams.MaterialParameters.Density.compute_density!
 ```
-Note that density values are usually not used in itself in the governing PDE's, but usually in combination with other parameters, such as $\rho g$ or $\rho c_p$. the non-dimensional value of $\rho$ may thus have very large or small values, but multiplied with the other values one often obtains numbers that are closer to one.
+Note that density values are usually not used in itself in the governing PDE's, but usually in combination with other parameters, such as $\rho g$ or $\rho c_p$. The non-dimensional value of $\rho$ may thus have very large or small values, but multiplied with the other values one often obtains numbers that are closer to one.

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -288,9 +288,9 @@ c =
 - `ρmelt`: Density of the melt
 - `ρgas`: Density of the gas
 - `c0`: Total volatile content
-- `a`: Gas solubility constant (default: 0.0041MPa``^{-1/2}``) (after Sparks et al., 1978)
+- `a`: Gas solubility constant (default: 4.1e-6Pa``^{-1/2}``) (after Sparks et al., 1978)
 
-Possible values for a are 0.0032-0.0064MPa``^{-1/2}`` where the lower value corresponds to mafic magmas at rather large pressures (400-600MPa) and the higher value to felsic magmas at low pressures (0 to 100-200MPa) (after Slezin (2003))
+Possible values for a are 3.2e-6-6.4e-6Pa``^{-1/2}`` where the lower value corresponds to mafic magmas at rather large pressures (400-600MPa) and the higher value to felsic magmas at low pressures (0 to 100-200MPa) (after Slezin (2003))
 
 # Example
 ```julia
@@ -310,7 +310,7 @@ rheology = SetMaterialParams(;
     ρmelt::S1 = ConstantDensity(ρ=2200kg/m^3)   # density of the melt
     ρgas::S2 = ConstantDensity(ρ=1kg/m^3)       # density of the gas
     c0::GeoUnit{_T, U1} = 0e0 * NoUnits         # total volatile content
-    a::GeoUnit{_T, U2} = 0.0041MPa^(-1//2)      # gas solubility constant
+    a::GeoUnit{_T, U2} = 4.1e-6Pa^(-1//2)         # gas solubility constant
     ρ::GeoUnit{_T,U3} = 2900.0kg / m^3          # to keep track on whether this struct is dimensional or not
 end
 

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -334,7 +334,7 @@ end
     cutoff = c0^2/a^2
 
     if P < cutoff
-        c = a * sqrt(P)
+        c = a * sqrt(abs(P))
     else
         c = c0
     end
@@ -561,7 +561,7 @@ function get_α(rho::BubbleFlow_Density; P::T=0.0, kwargs...) where {T}
     cutoff = c0^2/a^2
 
     if P < cutoff
-        c = a * sqrt(P)
+        c = a * sqrt(abs(P))
     else
         c = c0
     end

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -334,12 +334,12 @@ end
     cutoff = c0^2/a^2
 
     if P < cutoff
-        c = a * P^(1//2)
+        c = a * sqrt(P)
     else
         c = c0
     end
 
-    return 1e0/(((c0-c)/ρgas) + ((1-(c0-c))/ρmelt))
+    return inv((c0-c)/ρgas + (1-(c0-c))/ρmelt)
 end
 
 @inline (s::BubbleFlow_Density)(args)                = s(; args...)
@@ -561,12 +561,12 @@ function get_α(rho::BubbleFlow_Density; P::T=0.0, kwargs...) where {T}
     cutoff = c0^2/a^2
 
     if P < cutoff
-        c = a * P^(1//2)
+        c = a * sqrt(P)
     else
         c = c0
     end
 
-    return 1e0/(((c0-c)/αgas) + ((1-(c0-c))/αmelt))
+    return 1inv((c0-c)/αgas) + (1-(c0-c))/αmelt)
 end
 
 get_α(rho::BubbleFlow_Density, args) = get_α(rho; args...)

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -566,7 +566,7 @@ function get_α(rho::BubbleFlow_Density; P::T=0.0, kwargs...) where {T}
         c = c0
     end
 
-    return 1inv((c0-c)/αgas) + (1-(c0-c))/αmelt)
+    return inv((c0-c)/αgas + (1-(c0-c))/αmelt)
 end
 
 get_α(rho::BubbleFlow_Density, args) = get_α(rho; args...)

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -276,7 +276,14 @@ Defines the BubbleFlow_Density as descriped in Slezin (2003) with a default gas 
 ```math
     \\rho = \\frac{1}{\\frac{c_0 - c}{\\rho_g} + \\frac{1-(c_0-c)}{\\rho_m}}
 ```
-
+with
+```math
+c =
+\\begin{cases}
+   aP^{1/2} & \\text{for } P < \\frac{c_0^2}{a^2} \\\\
+    c_0 & \\text{for } P \\geq \\frac{c_0^2}{a^2}
+\\end{cases}
+```
 # Arguments
 - `ρmelt`: Density of the melt
 - `ρgas`: Density of the gas
@@ -299,11 +306,11 @@ rheology = SetMaterialParams(;
 - Slezin, Yu. B. (2003), The mechanism of volcanic eruptions (a steady state approach), Journal of Volcanology and Geothermal Research, 122, 7-50, https://doi.org/10.1016/S0377-0273(02)00464-X
 - Sparks, R. S. J.(1978), The dynamics of bubble formation and growth in magmas: A review and analysis, Journal of Volcanology and Geothermal Research, 3, 1-37, https://doi.org/10.1016/0377-0273(78)90002-1
 """
-@with_kw_noshow struct BubbleFlow_Density{_T, U1, U2, U3, S1<:AbstractDensity, S2 <:AbstractDensity, S3} <: ConduitDensity{_T}
+@with_kw_noshow struct BubbleFlow_Density{_T, U1, U2, U3, S1<:AbstractDensity, S2 <:AbstractDensity} <: ConduitDensity{_T}
     ρmelt::S1 = ConstantDensity(ρ=2900kg/m^3)   # density of the melt
     ρgas::S2 = ConstantDensity(ρ=1kg/m^3)       # density of the gas
-    c0::GeoUnit{_T, U1} = 0e0                   # total volatile content
-    a::GeoUnit{_T, U2} = 0.0041MPa^-1//2        # gas solubility constant
+    c0::GeoUnit{_T, U1} = 0e0 * NoUnits         # total volatile content
+    a::GeoUnit{_T, U2} = 0.0041MPa^(-1//2)      # gas solubility constant
     ρ::GeoUnit{_T,U3} = 2900.0kg / m^3          # to keep track on whether this struct is dimensional or not
 end
 
@@ -328,7 +335,7 @@ end
         c = c0
     end
 
-    return 1/(((c0-c)/ρgas) + (1-(c0-c))/ρmelt)
+    return inv(((c0-c)/ρgas) + (1-(c0-c))/ρmelt)
 end
 
 @inline (s::BubbleFlow_Density)(args)                = s(; args...)
@@ -376,9 +383,9 @@ rheology = SetMaterialParams(;
 @with_kw_noshow struct GasPyroclast_Density{_T, U1, U2, U3, S1<:AbstractDensity, S2 <:AbstractDensity, S3} <: ConduitDensity{_T}
     ρmelt::S1 = ConstantDensity(ρ=2900kg/m^3)   # density of the melt
     ρgas::S2 = ConstantDensity(ρ=1kg/m^3)       # density of the gas
-    δ::GeoUnit{_T, U1} = 0e0                    # volume fraction of fee gas in flow
-    β::GeoUnit{_T, U2} = 0e0                    # gas volume fraction enclosed within the particles
-    ρ::GeoUnit{_T,U2} = 2900.0kg / m^3          # to keep track on whether this struct is dimensional or not
+    δ::GeoUnit{_T, U1} = 0e0 * NoUnits          # volume fraction of free gas in flow
+    β::GeoUnit{_T, U2} = 0e0 * NoUnits          # gas volume fraction enclosed within the particles
+    ρ::GeoUnit{_T, U3} = 2900.0kg / m^3         # to keep track on whether this struct is dimensional or not
 end
 
 GasPyroclast_Density(args...) = GasPyroclast_Density(args[1], args[2], convert.(GeoUnit, args[3:end])...)

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -272,7 +272,7 @@ end
 """
     BubbleFlow_Density(ρmelt=ConstantDensity(), ρgas=ConstantDensity(), c0=0e0, a=0.0041MPa^-1/2)
 
-Defines the BubbleFlow_Density as descriped in Slezin (2003) with a default gas solubility constant of 0.0041MPa``^{-1/2}`` used in e.g. Sparks et al. (1978)
+Defines the BubbleFlow_Density as described in Slezin (2003) with a default gas solubility constant of 0.0041MPa``^{-1/2}`` used in e.g. Sparks et al. (1978)
 ```math
     \\rho = \\frac{1}{\\frac{c_0 - c}{\\rho_g} + \\frac{1-(c_0-c)}{\\rho_m}}
 ```
@@ -354,7 +354,7 @@ end
 """
     GasPyroclast_Density(ρmelt=ConstantDensity(), ρgas=ConstantDensity(), δ=0e0)
 
-Defines the GasPyroclast_Density as descriped in Slezin (2003) with a default volume fraction of free gas in the flow of 0.0
+Defines the GasPyroclast_Density as described in Slezin (2003) with a default volume fraction of free gas in the flow of 0.0
 This is also used to model partly destroyed foam in the conduit.
 
 ```math

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -16,7 +16,6 @@ using Parameters         # helps setting default parameters in structures
 using Unitful            # Units
 using BibTeX             # references of creep laws
 using StaticArrays
-using Requires: @require
 using LinearAlgebra
 using ForwardDiff
 using MuladdMacro

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -16,6 +16,7 @@ using Parameters         # helps setting default parameters in structures
 using Unitful            # Units
 using BibTeX             # references of creep laws
 using StaticArrays
+using Requires: @require
 using LinearAlgebra
 using ForwardDiff
 using MuladdMacro
@@ -120,6 +121,7 @@ export compute_density,                                # computational routines
     compute_density!,
     param_info,
     AbstractDensity,
+    ConduitDensity,
     No_Density,
     ConstantDensity,
     PT_Density,
@@ -129,6 +131,8 @@ export compute_density,                                # computational routines
     PhaseDiagram_LookupTable,
     Read_LaMEM_Perple_X_Diagram,
     MeltDependent_Density,
+    BubbleFlow_Density,
+    GasPyroclast_Density,
     compute_density_ratio
 
 # Constitutive relationships laws
@@ -432,6 +436,17 @@ export PlotStrainrateStress,
     PlotPressureStressTime_0D,
     StrengthEnvelopePlot
 
+# We do not check `isdefined(Base, :get_extension)` as recommended since
+# Julia v1.9.0 does not load package extensions when their dependency is
+# loaded from the main environment.
+function __init__()
+   @static if !(VERSION >= v"1.9.1")
+       @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" begin
+           print("Adding plotting routines of GeoParams through GLMakie \n")
+           @eval include("../ext/GeoParamsGLMakieExt.jl")
+       end
+   end
+end
 #Set functions aliases using @use
 include("aliases.jl")
 export ntuple_idx

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -436,17 +436,6 @@ export PlotStrainrateStress,
     PlotPressureStressTime_0D,
     StrengthEnvelopePlot
 
-# We do not check `isdefined(Base, :get_extension)` as recommended since
-# Julia v1.9.0 does not load package extensions when their dependency is
-# loaded from the main environment.
-function __init__()
-   @static if !(VERSION >= v"1.9.1")
-       @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" begin
-           print("Adding plotting routines of GeoParams through GLMakie \n")
-           @eval include("../ext/GeoParamsGLMakieExt.jl")
-       end
-   end
-end
 #Set functions aliases using @use
 include("aliases.jl")
 export ntuple_idx

--- a/src/MaterialParameters.jl
+++ b/src/MaterialParameters.jl
@@ -53,7 +53,7 @@ include("./Energy/RadioactiveHeat.jl")
 include("./Energy/Shearheating.jl")
 include("./SeismicVelocity/SeismicVelocity.jl")
 
-using .Density: AbstractDensity
+using .Density: AbstractDensity, ConduitDensity
 using .ConstitutiveRelationships: print_rheology_matrix
 
 

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -33,6 +33,16 @@ import ForwardDiff.derivative
     @test param_info(x).Equation === L"$\rho = \rho_0*(1 - \alpha*(T-T_0))$"
     @test isdimensional(x) === true
 
+    x = BubbleFlow_Density()
+    @test isbits(x)
+    @test param_info(x).Equation === L"\rho = 1/((c_0-c)/rho_g + 1-(c_0-c)/\rho_m)"
+    @test isdimensional(x) === true
+
+    # x = GasPyroclast_Density()
+    # @test isbits(x)
+    # @test param_info(x).Equation === L"\rho = 1/((c0-c)/rho_g + 1-(c0-c)/\rho_m)"
+    # @test isdimensional(x) === true
+
     # This tests the MaterialParameters structure
     CharUnits_GEO = GEO_units(; viscosity=1e19, length=1000km)
 

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -399,13 +399,13 @@ import ForwardDiff.derivative
     @test isdimensional(x_D)==true
     @test isdimensional(x_ND)==false
 
-    args = (P=100.0, T=00.0+273.15)
+    args = (P=1e8, T=00.0+273.15)
     ρmelt = compute_density(x_D.ρmelt, args)
     ρgas  = compute_density(x_D.ρgas, args)
     ρ     = compute_density(x_D, args)
 
-    cutoff = 0.1^2/0.0041^2
-    c_theoretical = 0.0041 * args.P^(1//2)
+    cutoff = 0.1^2/4.1e-6^2
+    c_theoretical = 4.1e-6 * sqrt(args.P)
     @test ρmelt ≈ 2200.0
     @test ρgas ≈ 1.0
     @test ρ ≈ inv((x_D.c0-c_theoretical)/ρgas + (1-(x_D.c0-c_theoretical))/ρmelt)
@@ -422,7 +422,7 @@ import ForwardDiff.derivative
     @test derivative(x -> compute_density(x_D.ρgas,  (P=args.P, T=x)), args.T) == 0.0
     @test derivative(x -> compute_density(x_D.ρgas,  (P=x, T=args.T)), args.P) == 0.0
     @test derivative(x -> compute_density(x_D,        (P=args.P, T=x)), args.T) == 0.0
-    @test derivative(x -> compute_density(x_D,        (P=x, T=args.T)), args.P) ≈ 0.0580200590363328 rtol = 1e-6
+    @test derivative(x -> compute_density(x_D,        (P=x, T=args.T)), args.P) ≈ 5.8020059036332765e-8 rtol = 1e-6
 
     rheologies = (
         SetMaterialParams(;
@@ -440,15 +440,15 @@ import ForwardDiff.derivative
     )
     PhaseRatio = (0.5, 0.5)
 
-    args = (P=100.0, T=00.0+273.15)
+    args = (P=1e8, T=00.0+273.15)
     @test compute_density_ratio(PhaseRatio, rheologies, args) == compute_density(rheologies, PhaseRatio, args) == ρ
 
     @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=args.P, T=x)), args.T) == 0.0
-    @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=x, T=args.T)), args.P) ≈ 0.0580200590363328 rtol = 1e-6
+    @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=x, T=args.T)), args.P) ≈ 5.8020059036332765e-8 rtol = 1e-6
 
     rho = zeros(size(Phases))
     T = fill(20.0+273.15, size(Phases))
-    P = fill(100.0, size(Phases))
+    P = fill(1e8, size(Phases))
 
     args_vec = (P=P, T=T)
 
@@ -463,7 +463,7 @@ import ForwardDiff.derivative
     @test isdimensional(x_D)==true
     @test isdimensional(x_ND)==false
 
-    args = (P=100.0, T=00.0+273.15)
+    args = (P=1e8, T=00.0+273.15)
 
     ρmelt = compute_density(x_D.ρmelt, args)
     ρgas  = compute_density(x_D.ρgas, args)
@@ -503,7 +503,7 @@ import ForwardDiff.derivative
     )
 
     PhaseRatio = (0.5, 0.5)
-    args = (P=100.0, T=00.0+273.15)
+    args = (P=1e8, T=00.0+273.15)
     @test compute_density_ratio(PhaseRatio, rheologies, args) == compute_density(rheologies, PhaseRatio, args) == ρ
 
     @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=args.P, T=x)), args.T) == 0.0
@@ -511,7 +511,7 @@ import ForwardDiff.derivative
 
     rho = zeros(size(Phases))
     T = fill(20.0+273.15, size(Phases))
-    P = fill(100.0, size(Phases))
+    P = fill(1e8, size(Phases))
 
     args_vec = (P=P, T=T)
 

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -120,7 +120,7 @@ import ForwardDiff.derivative
     @test derivative(x->compute_density(Compressible_Density(), (P=x, T=args.T)), args.P) ≈ 2.90000290000145e-6 rtol = 1e-6
 
     # Read Phase diagram interpolation object
-    fname = "./test/test_data/Peridotite_dry.in"
+    fname = "test_data/Peridotite_dry.in"
     PD_data = PerpleX_LaMEM_Diagram(fname)
     @test PD_data.meltFrac(1500, 1e7) ≈ 0.2538048323727155
     @test PD_data.Rho(1500, 1e7) ≈ 3054.8671154189938
@@ -177,7 +177,7 @@ import ForwardDiff.derivative
         Name="Mantle",
         Phase=0,
         CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e23Pa * s)),
-        Density=PerpleX_LaMEM_Diagram("./test/test_data/sediments_1.in"),
+        Density=PerpleX_LaMEM_Diagram("test_data/sediments_1.in"),
     )
 
     MatParam[2] = SetMaterialParams(;

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -408,7 +408,7 @@ import ForwardDiff.derivative
     c_theoretical = 0.0041 * args.P^(1//2)
     @test ρmelt ≈ 2200.0
     @test ρgas ≈ 1.0
-    @test ρ ≈ 1e0/(((x_D.c0-c_theoretical)/ρgas) + ((1-(x_D.c0-c_theoretical))/ρmelt))
+    @test ρ ≈ inv((x_D.c0-c_theoretical)/ρgas + (1-(x_D.c0-c_theoretical))/ρmelt)
 
     x = BubbleFlow_Density(
         ρmelt = PT_Density(α= 1e-3),
@@ -422,7 +422,7 @@ import ForwardDiff.derivative
     @test derivative(x -> compute_density(x_D.ρgas,  (P=args.P, T=x)), args.T) == 0.0
     @test derivative(x -> compute_density(x_D.ρgas,  (P=x, T=args.T)), args.P) == 0.0
     @test derivative(x -> compute_density(x_D,        (P=args.P, T=x)), args.T) == 0.0
-    @test derivative(x -> compute_density(x_D,        (P=x, T=args.T)), args.P) == 0.0580200590363328
+    @test derivative(x -> compute_density(x_D,        (P=x, T=args.T)), args.P) ≈ 0.0580200590363328 rtol = 1e-6
 
     rheologies = (
         SetMaterialParams(;
@@ -444,7 +444,7 @@ import ForwardDiff.derivative
     @test compute_density_ratio(PhaseRatio, rheologies, args) == compute_density(rheologies, PhaseRatio, args) == ρ
 
     @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=args.P, T=x)), args.T) == 0.0
-    @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=x, T=args.T)), args.P) == 0.0580200590363328
+    @test derivative(x -> compute_density_ratio(PhaseRatio, rheologies, (P=x, T=args.T)), args.P) ≈ 0.0580200590363328 rtol = 1e-6
 
     rho = zeros(size(Phases))
     T = fill(20.0+273.15, size(Phases))


### PR DESCRIPTION
This pull request introduces new density calculation models for magma densities in conduit flows. 

## 1.   `BubbleFlow_Density`

Defines the BubbleFlow_Density as described in Slezin (2003) with a default gas solubility constant of 0.0041MPa^{-1/2} used in e.g. Sparks et al. (1978)
```math
    \rho = \frac{1}{\frac{c_0 - c}{\rho_g} + \frac{1-(c_0-c)}{\rho_m}}
```
with
```math
c =
\begin{cases}
   aP^{1/2} & \text{for } P < \frac{c_0^2}{a^2} \\
    c_0 & \text{for } P \geq \frac{c_0^2}{a^2}
\end{cases}
```
### Arguments
- `ρmelt`: Density of the melt
- `ρgas`: Density of the gas
- `c0`: Total volatile content
- `a`: Gas solubility constant (default: 0.0041MPa^{-1/2}) (after Sparks et al., 1978)
Possible values for a are 0.0032-0.0064MPa``^{-1/2}`` where the lower value corresponds to mafic magmas at rather large pressures (400-600MPa) and the higher value to felsic magmas at low pressures (0 to 100-200MPa) (after Slezin (2003))

### Example
```julia
rheology = SetMaterialParams(;
                      Phase=1,
                      CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e21Pa * s)),
                      Gravity=ConstantGravity(; g=9.81.0m / s^2),
                      Density= BubbleFlow_Density(ρmelt=ConstantDensity(ρ=2900kg/m^3), ρgas=ConstantDensity(ρ=1kg/m^3), c0=0.0, a=0.0041MPa^-1//2),
                      )
```

### References
- Slezin, Yu. B. (2003), The mechanism of volcanic eruptions (a steady state approach), Journal of Volcanology and Geothermal Research, 122, 7-50, https://doi.org/10.1016/S0377-0273(02)00464-X
- Sparks, R. S. J.(1978), The dynamics of bubble formation and growth in magmas: A review and analysis, Journal of Volcanology and Geothermal Research, 3, 1-37, https://doi.org/10.1016/0377-0273(78)90002-1

## 2. `GasPyroclast_Density`

Defines the GasPyroclast_Density as described in Slezin (2003) with a default volume fraction of free gas in the flow of 0.0
This is also used to model partly destroyed foam in the conduit.

```math
    \rho = \rho_g\delta + \rho_p(1 - \delta)
```
with
```math
    \rho_p = \rho_m(1 - \beta) + \rho_g\beta \approx \rho_l(1 - \beta)
```

### Arguments
- `ρmelt`: Density of the melt
- `ρgas`: Density of the gas
- `δ`: Volume fraction of free gas in the flow
- `β`: Gas volume fraction enclosed within the particles

### Example
```julia
rheology = SetMaterialParams(;
                      Phase=1,
                      CreepLaws=(PowerlawViscous(), LinearViscous(; η=1e21Pa * s)),
                      Gravity=ConstantGravity(; g=9.81.0m / s^2),
                      Density= GasPyroclast_Density(ρmelt=ConstantDensity(ρ=2900kg/m^3), ρgas=ConstantDensity(ρ=1kg/m^3), δ=0.0, β=0.0),
                      )
```

### References
- Slezin, Yu. B. (2003), The mechanism of volcanic eruptions (a steady state approach), Journal of Volcanology and Geothermal Research, 122, 7-50, https://doi.org/10.1016/S0377-0273(02)00464-X 