### PR TITLE
Plane Strain component in 2nd invariant calculations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoParams"
 uuid = "e018b62d-d9de-4a26-8697-af89c310ae38"
 authors = ["Boris Kaus <kaus@uni-mainz.de>, Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 BibTeX = "7b0aa2c9-049f-5cec-894a-2b6b781bb25e"

--- a/src/Plotting/StrengthEnvelope.jl
+++ b/src/Plotting/StrengthEnvelope.jl
@@ -16,7 +16,7 @@ function StrengthEnvelopePlot(MatParam::NTuple{N, AbstractMaterialParamsStruct},
         title = "1D Strength Envelope (Linear T-profile, Ttop = 0C)"
         Ttop = 0C
         # Tbot controlled by slider
-    elseif typeof(TempType) == HalfspaceCoolTemp
+    elseif typeof(TempType) == HalfspaceCoolingTemp
         Ttype = 2
         title = "1D Strength Envelope (Halfspace-cooling T-profile, Ttop = 0C, Tmantle = 1350C)"
         Ttop = 0C

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -87,6 +87,18 @@ import ForwardDiff as FD
         @test length(k_TP_test.Name) == length(name)
     end
 
+    TP_indirect = TP_Conductivity(;
+            a = 1.72,
+            b = 807.0e0,
+            c = 350,
+            d = 0.0,
+        )
+    @test isbits(TP_indirect)
+    @test TP_indirect.a.val == 1.72
+    @test TP_indirect.b.val == 807.0
+    @test TP_indirect.c.val == 350
+    @test TP_indirect.d.val == 0.0
+
     # Test with arrays
     T_array = T * ones(10)'
     Cp_array = similar(T_array)

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -88,11 +88,11 @@ import ForwardDiff as FD
     end
 
     TP_indirect = TP_Conductivity(;
-            a = 1.72,
-            b = 807.0e0,
-            c = 350,
-            d = 0.0,
-        )
+        a = 1.72,
+        b = 807.0e0,
+        c = 350,
+        d = 0.0,
+    )
     @test isbits(TP_indirect)
     @test TP_indirect.a.val == 1.72
     @test TP_indirect.b.val == 807.0

--- a/test/test_TensorAlgebra.jl
+++ b/test/test_TensorAlgebra.jl
@@ -74,7 +74,9 @@ end
 @testset "Tensor algebra" begin
     # J2 TENSOR INVARIANT: 2D TESTS
     τ_xx, τ_yy, τ_xy = 1.0, 2.0, 3.0
-    τII = √(0.5 * (τ_xx^2 + τ_yy^2) + τ_xy^2)
+    # Include the third diagonal component for plane strain: τ_zz = -τ_xx - τ_yy
+    τ_zz = -τ_xx - τ_yy  # = -1.0 - 2.0 = -3.0
+    τII = √(0.5 * (τ_xx^2 + τ_yy^2 + τ_zz^2) + τ_xy^2)
 
     # test standard 2D interfaces
     @test τII == second_invariant(τ_xx, τ_yy, τ_xy)
@@ -84,7 +86,8 @@ end
     # test for staggered grids
     τ_xy_ij = τ_xy_11, τ_xy_12, τ_xy_21, τ_xy_22 = 3.0, 3.0, 3.5, 3.5 # shear stress at the center of the cell around the grid nodes
     τ_xy2_av = sum(ij^2 for ij in τ_xy_ij) * 0.25
-    τII = √(0.5 * (τ_xx^2 + τ_yy^2) + τ_xy2_av)
+    # Include the third diagonal component in staggered calculation
+    τII = √(0.5 * (τ_xx^2 + τ_yy^2 + (-τ_xx - τ_yy)^2) + τ_xy2_av)
     @test τII == second_invariant_staggered(τ_xx, τ_yy, τ_xy_ij)
 
     # J2 TENSOR INVARIANT: 3D TESTS


### PR DESCRIPTION
This PR adds the missing plane strain terms for the compressible case (`Tzz = -Txx-Tyy, Ezz = -Exx-Eyy`). In case of incompressibility, it will be zero. 