### PR TITLE
[BUGFIX] Fix stack overflow then radioactive heating is empty

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoParams"
 uuid = "e018b62d-d9de-4a26-8697-af89c310ae38"
 authors = ["Boris Kaus <kaus@uni-mainz.de>, Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.13"
+version = "0.7.14"
 
 [deps]
 BibTeX = "7b0aa2c9-049f-5cec-894a-2b6b781bb25e"

--- a/src/Energy/RadioactiveHeat.jl
+++ b/src/Energy/RadioactiveHeat.jl
@@ -130,7 +130,7 @@ end
 #-------------------------------------------------------------------------
 
 # Computational routines needed for computations with the MaterialParams structure
-function compute_radioactive_heat(s::AbstractMaterialParamsStruct, args)
+function compute_radioactive_heat(s::AbstractMaterialParamsStruct, args::Vararg{Any, N}) where {N}
     if isempty(s.RadioactiveHeat)
         return isempty(args) ? 0.0 : zero(typeof(args).types[1])  # return zero if not specified
     else

--- a/src/Energy/RadioactiveHeat.jl
+++ b/src/Energy/RadioactiveHeat.jl
@@ -132,9 +132,9 @@ end
 # Computational routines needed for computations with the MaterialParams structure
 function compute_radioactive_heat(s::AbstractMaterialParamsStruct, args::Vararg{Any, N}) where {N}
     if isempty(s.RadioactiveHeat)
-        return isempty(args) ? 0.0 : zero(typeof(args).types[1])  # return zero if not specified
+        return 0.0  # return zero if not specified
     else
-        return s.RadioactiveHeat[1](args)
+        return compute_radioactive_heat(s.RadioactiveHeat[1], args...)
     end
 end
 


### PR DESCRIPTION
### Whats the purpose of this PR?
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

There was an issue of resulting in a stack overflow when trying to compute radioactive heating when this is not specified in the materials struct. This PR fixes this bug

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests were added, or old tests were updated
- [ ] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [ ] The new code follows the [Runic Style](https://github.com/fredrikekre/Runic.jl)
