### PR TITLE
[FIX] A few bugs and ambiguities

### DIFF
--- a/src/ConstitutiveRelationships.jl
+++ b/src/ConstitutiveRelationships.jl
@@ -12,7 +12,7 @@ import GeoParams: second_invariant, second_invariant_staggered, value_and_partia
 using BibTeX
 using ..MaterialParameters: MaterialParamsInfo
 import Base.show
-using ForwardDiff, StaticArrays, Static
+using ForwardDiff, StaticArrays, Static, LinearAlgebra
 
 const AxialCompression, SimpleShear, Invariant = 1, 2, 3
 

--- a/src/Plasticity/DruckerPrager.jl
+++ b/src/Plasticity/DruckerPrager.jl
@@ -69,9 +69,9 @@ function (s::DruckerPrager)(;
 end
 
 
-function (s::DruckerPrager{_T, U, U1, NoSoftening, AbstractSoftening})(;
+function (s::DruckerPrager{_T, U, U1, NoSoftening, S2})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...
-    ) where {_T, U, U1}
+    ) where {_T, U, U1, S2 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
     C = s.softening_C(EII, C)
     C *= perturbation_C
@@ -80,9 +80,9 @@ function (s::DruckerPrager{_T, U, U1, NoSoftening, AbstractSoftening})(;
     return F
 end
 
-function (s::DruckerPrager{_T, U, U1, AbstractSoftening, NoSoftening})(;
+function (s::DruckerPrager{_T, U, U1, S1, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...
-    ) where {_T, U, U1}
+    ) where {_T, U, U1, S1 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, ϕ, C = s
     ϕ = s.softening_ϕ(EII, ϕ)
     C *= perturbation_C
@@ -173,16 +173,9 @@ end
 
 This computes plastic strain rate invariant for a given ``λdot``
 """
-function compute_εII(p::DruckerPrager{_T, U, U1}, λdot::_T, τII::_T, kwargs...) where {_T, U, U1}
-    F = compute_yieldfunction(p, kwargs)
-    if F > 0
-        ε_pl = λdot * ∂Q∂τII(p, τII)
-
-    else
-        ε_pl = 0.0
-    end
-
-    return ε_pl
+function compute_εII(p::DruckerPrager{_T, U, U1}, λdot::_T, τII::_T, args::NamedTuple = NamedTuple()) where {_T, U, U1}
+    F = compute_yieldfunction(p, args)
+    return F > 0 ? λdot * ∂Q∂τII(p, τII) : zero(_T)
 end
 
 # Print info
@@ -208,8 +201,8 @@ end
     `K` is the elastic bulk modulus, h is the harderning, and `τij`` is the stress tensor in Voigt notation.
     Equations from Duretz et al. 2019 G3
 """
-@inline function lambda(F::T, p::DruckerPrager, ηve::T, ηvp::T; K = zero(T), dt = zero(T), EII = zero(T), τij = (one(T), one(T), one(T))) where {T}
-    ϕ = s.softening_ϕ(p.cosϕ, EII)
-    return F * inv(ηve + ηvp + K * dt * p.sinΨ * p.sinϕ + h * cosdϕ * plastic_strain(p, τij, zero(T)))
+@inline function lambda(F::T, p::DruckerPrager, ηve::T, ηvp::T; K = zero(T), dt = zero(T), h = zero(T), τij = (one(T), one(T), one(T))) where {T}
+    @unpack_val sinϕ, cosϕ, sinΨ = p
+    return F * inv(ηve + ηvp + K * dt * sinΨ * sinϕ + h * cosϕ * plastic_strain(p, τij, zero(T)))
 end
 #-------------------------------------------------------------------------

--- a/src/Plasticity/DruckerPragerCap.jl
+++ b/src/Plasticity/DruckerPragerCap.jl
@@ -71,8 +71,10 @@ end
 
 function _promote_cap_pressure_units(C::GeoUnit, pT::GeoUnit)
     if !isdimensional(C) && isdimensional(pT)
+        @warn "DruckerPragerCap: C was given without units but pT carries units; interpreting C in $(pT.unit). " maxlog = 1
         return GeoUnit(C.val * pT.unit), pT
     elseif isdimensional(C) && !isdimensional(pT)
+        @warn "DruckerPragerCap: pT was given without units but C carries units; interpreting pT in $(C.unit). " maxlog = 1
         return C, GeoUnit(pT.val * C.unit)
     end
     return C, pT

--- a/src/Plasticity/DruckerPragerCap.jl
+++ b/src/Plasticity/DruckerPragerCap.jl
@@ -207,9 +207,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, NoSoftening, NoSofteni
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, NoSoftening, AbstractSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, NoSoftening, S3})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2, AbstractSoftening}
+    ) where {_T, U, U1, U2, S3 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     Ψ = s.softening_Ψ(EII, Ψ)
     C *= perturbation_C
@@ -221,9 +221,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, NoSoftening, AbstractS
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, AbstractSoftening, AbstractSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, S2, S3})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2, AbstractSoftening}
+    ) where {_T, U, U1, U2, S2 <: AbstractSoftening, S3 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     C = s.softening_C(EII, C)
     Ψ = s.softening_Ψ(EII, Ψ)
@@ -236,9 +236,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, AbstractSoftening, Abs
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, AbstractSoftening, NoSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, S2, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2, AbstractSoftening}
+    ) where {_T, U, U1, U2, S2 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     C = s.softening_C(EII, C)
     C *= perturbation_C
@@ -249,9 +249,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, NoSoftening, AbstractSoftening, NoS
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, AbstractSoftening, AbstractSoftening, NoSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, S1, S2, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2, AbstractSoftening}
+    ) where {_T, U, U1, U2, S1 <: AbstractSoftening, S2 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     ϕ = s.softening_ϕ(EII, ϕ)
     C = s.softening_C(EII, C)
@@ -264,9 +264,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, AbstractSoftening, AbstractSoftenin
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, AbstractSoftening, NoSoftening, NoSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, S1, NoSoftening, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2}
+    ) where {_T, U, U1, U2, S1 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     ϕ = s.softening_ϕ(EII, ϕ)
     C *= perturbation_C
@@ -278,9 +278,9 @@ function (s::DruckerPragerCap{_T, U, U1, U2, AbstractSoftening, NoSoftening, NoS
     return F
 end
 
-function (s::DruckerPragerCap{_T, U, U1, U2, AbstractSoftening, NoSoftening, AbstractSoftening})(;
+function (s::DruckerPragerCap{_T, U, U1, U2, S1, NoSoftening, S3})(;
         P = 0.0, τII = 0.0, Pf = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...,
-    ) where {_T, U, U1, U2}
+    ) where {_T, U, U1, U2, S1 <: AbstractSoftening, S3 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, sinΨ, ϕ, Ψ, C, pT = s
     ϕ = s.softening_ϕ(EII, ϕ)
     Ψ = s.softening_Ψ(EII, Ψ)

--- a/src/Plasticity/DruckerPrager_regularised.jl
+++ b/src/Plasticity/DruckerPrager_regularised.jl
@@ -70,9 +70,9 @@ function (s::DruckerPrager_regularised)(;
     return F
 end
 
-function (s::DruckerPrager_regularised{_T, U, U1, NoSoftening, AbstractSoftening})(;
+function (s::DruckerPrager_regularised{_T, U, U1, U2, NoSoftening, S2})(;
         P = 0.0, τII = 0.0, Pf = 0.0, λ = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...
-    ) where {_T, U, U1, AbstractSoftening}
+    ) where {_T, U, U1, U2, S2 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     C = s.softening_C(EII, C)
     C *= perturbation_C
@@ -82,9 +82,9 @@ function (s::DruckerPrager_regularised{_T, U, U1, NoSoftening, AbstractSoftening
     return F
 end
 
-function (s::DruckerPrager_regularised{_T, U, U1, AbstractSoftening, NoSoftening})(;
+function (s::DruckerPrager_regularised{_T, U, U1, U2, S1, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, λ = 0.0, EII = 0.0, perturbation_C = 1.0, kwargs...
-    ) where {_T, U, U1}
+    ) where {_T, U, U1, U2, S1 <: AbstractSoftening}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     ϕ = s.softening_ϕ(EII, ϕ)
     C *= perturbation_C
@@ -96,9 +96,9 @@ function (s::DruckerPrager_regularised{_T, U, U1, AbstractSoftening, NoSoftening
     return F
 end
 
-function (s::DruckerPrager_regularised{_T, U, U1, NoSoftening, NoSoftening})(;
+function (s::DruckerPrager_regularised{_T, U, U1, U2, NoSoftening, NoSoftening})(;
         P = 0.0, τII = 0.0, Pf = 0.0, λ = 0.0, perturbation_C = 1.0, kwargs...
-    ) where {_T, U, U1}
+    ) where {_T, U, U1, U2}
     @unpack_val sinϕ, cosϕ, ϕ, C, η_vp = s
     C *= perturbation_C
     ε̇II_pl = λ * ∂Q∂τII(s, τII)  # plastic strainrate
@@ -179,17 +179,10 @@ end
 
 This computes plastic strain rate invariant for a given ``λdot``
 """
-function compute_εII(p::DruckerPrager_regularised{_T, U, U1}, λdot::_T, τII::_T, kwargs...) where {_T, U, U1}
-    args = merge(kwargs, (λ = λdot,))
+function compute_εII(p::DruckerPrager_regularised{_T, U, U1}, λdot::_T, τII::_T, args::NamedTuple = NamedTuple()) where {_T, U, U1}
+    args = merge(args, (λ = λdot,))
     F = compute_yieldfunction(p, args)
-    if F > 0
-        ε_pl = λdot * ∂Q∂τII(p, τII)
-
-    else
-        ε_pl = 0.0
-    end
-
-    return ε_pl
+    return F > 0 ? λdot * ∂Q∂τII(p, τII) : zero(_T)
 end
 
 # Print info

--- a/src/Plasticity/Plasticity.jl
+++ b/src/Plasticity/Plasticity.jl
@@ -46,7 +46,7 @@ end
 
 # Wrapper for arbitrary args in the form of a NamedTuple
 function ∂Q∂τ(p::AbstractPlasticity, args::NamedTuple; kwargs...)
-    return ∂Q∂τ(Q, args.τij, kwargs...)
+    return ∂Q∂τ(p, args.τij; kwargs...)
 end
 #-------------------------------------------------------------------------
 
@@ -64,13 +64,13 @@ function plastic_strain(εvp::T, p::AbstractPlasticity{T}, τij, λ̇::T, dt::T)
     return εvp += plastic_strain(p, τij, λ̇) * dt
 end
 
-@inline function plastic_strain(p::AbstractPlasticity{T}, τij::T, λ̇::T) where {T}
+@inline function plastic_strain(p::AbstractPlasticity{T}, τij, λ̇::T) where {T}
     εvp_ij = plastic_strain_rate(p, τij, λ̇)
     εvp = √((2.0 / 3.0) * dot(εvp_ij, εvp_ij))
     return εvp
 end
 
-@inline plastic_strain_rate(p::AbstractPlasticity{T}, τij::T, λ̇::T) where {T} = ∂Q∂τ(p, τij) .* λ̇
+@inline plastic_strain_rate(p::AbstractPlasticity{T}, τij, λ̇::T) where {T} = ∂Q∂τ(p, τij) .* λ̇
 #-------------------------------------------------------------------------
 
 # Computational routines needed for computations with the MaterialParams structure

--- a/src/Softening/Softening.jl
+++ b/src/Softening/Softening.jl
@@ -59,7 +59,13 @@ using SpecialFunctions
     σ::GeoUnit{T, U2} = 0.5NoUnits # standard deviation of the softening
 end
 
-NonLinearSoftening(args::Vararg{Any, N}) where {N} = NonLinearSoftening(convert.(GeoUnit, promote(args...))...)
+# restrict the positional constructors to the field count and route them through the
+# keyword constructor, so that partial positional input does not recurse infinitely
+NonLinearSoftening(ξ₀, Δ) = NonLinearSoftening(; ξ₀ = ξ₀, Δ = Δ)
+function NonLinearSoftening(args::Vararg{Any, 4})
+    ξ₀, Δ, μ, σ = convert.(GeoUnit, promote(args...))
+    return NonLinearSoftening(; ξ₀ = ξ₀, Δ = Δ, μ = μ, σ = σ)
+end
 
 @inline function (softening::NonLinearSoftening)(softening_var, ::Vararg{Any, N}) where {N}
     @unpack_val ξ₀, Δ, μ, σ = softening
@@ -72,7 +78,10 @@ end
     n::GeoUnit{T, U2} = 0.1
 end
 
-DecaySoftening(args::Vararg{Any, N}) where {N} = DecaySoftening(convert.(GeoUnit, promote(args...))...)
+function DecaySoftening(args::Vararg{Any, 2})
+    εref, n = convert.(GeoUnit, promote(args...))
+    return DecaySoftening(; εref = εref, n = n)
+end
 
 @inline function (softening::DecaySoftening)(softening_var::T, max_value::T) where {T}
     @unpack_val εref, n = softening

--- a/src/Softening/Softening.jl
+++ b/src/Softening/Softening.jl
@@ -28,11 +28,8 @@ struct LinearSoftening{T1, T2, T3} <: AbstractSoftening
 end
 
 function LinearSoftening(min_value::T1, max_value::T1, lo::T2, hi::T2) where {T1, T2}
-    slope = if T1 <: AbstractFloat
-        (max_value - min_value) / (hi - lo)
-    else
-        (max_value - min_value).val / (hi - lo)
-    end
+    # keep units here, so that the stored slope is consistently rescaled by nondimensionalize
+    slope = (max_value - min_value) / (hi - lo)
     return LinearSoftening(min_value, max_value, lo, hi, slope)
 end
 
@@ -40,12 +37,15 @@ LinearSoftening(min_max_values::NTuple{2, T1}, lo_hi::NTuple{2, T2}) where {T1, 
 
 @inline function (softening::LinearSoftening)(softening_var, max_value)
 
-    @unpack_val lo, hi, min_value, slope = softening
+    @unpack_val lo, hi, min_value = softening
 
     softening_var ≥ hi && return min_value
     softening_var ≤ lo && return max_value
 
-    return @muladd (1 - softening_var) * slope + min_value
+    # compute the slope on the fly from the current (consistently scaled) values,
+    # so that the result remains correct after nondimensionalization and for lo/hi ≠ (0, 1)
+    slope = (max_value - min_value) / (hi - lo)
+    return @muladd (hi - softening_var) * slope + min_value
 end
 
 ## Non linear softening

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -831,6 +831,7 @@ Dimensionalizes a material parameter structure (e.g., Density, CreepLaw)
             field = $(fields)[i]
             _dimensionalize(MatParam, getfield(MatParam, field), g, field)
         end
+        return MatParam   # needed so zero-field structs (e.g. NoSoftening) return the struct, not `nothing`
     end
 end
 

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -528,4 +528,26 @@ using GeoParams
         end
     end
 
+    @testset "plastic_strain / lambda" begin
+        mod = GeoParams.MaterialParameters.ConstitutiveRelationships
+        p = DruckerPrager(; ϕ = 30.0, Ψ = 10.0, C = 1.0e7Pa)
+        εvp = mod.plastic_strain(p, (1.0, 1.0, 1.0), 1.0e-15)
+        @test isfinite(εvp) && εvp > 0
+        @test isfinite(mod.lambda(1.0e6, p, 1.0e20, 1.0e19))
+        @test isfinite(mod.lambda(1.0e6, p, 1.0e20, 1.0e19; K = 2.0e10, dt = 1.0e3, h = 1.0e5, τij = (1.0e6, 1.0e6, 1.0e6)))
+    end
+
+    @testset "dimensionalize round-trip" begin
+        CharDim = GEO_units(; viscosity = 1.0e19, length = 10km)
+        @test dimensionalize(NoSoftening(), CharDim) === NoSoftening()
+        for p in (
+                DruckerPrager(; C = 1.0e7Pa, ϕ = 30.0),
+                DruckerPrager_regularised(; C = 1.0e7Pa, η_vp = 1.0e20Pa * s),
+                DruckerPragerCap(; C = 1.0e7Pa, pT = -5.0e5Pa, η_vp = 1.0e20Pa * s, Ψ = 10.0),
+            )
+            pd = dimensionalize(nondimensionalize(p, CharDim), CharDim)
+            @test pd.C.val ≈ p.C.val
+        end
+    end
+
 end

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -495,4 +495,37 @@ using GeoParams
         @test abs(F_check) < 1.0e-12
     end
 
+    @testset "no functor ambiguities" begin
+        # The specialized yield-function functors must each be a strict subtype of the
+        # generic one (free softening type vars bounded by AbstractSoftening), otherwise
+        # `compute_yieldfunction` throws a MethodError on real calls. Guard against the
+        # regression where the specializations were either dead or mutually ambiguous.
+        mod = GeoParams.MaterialParameters.ConstitutiveRelationships
+        amb = Test.detect_ambiguities(mod; recursive = false)
+        plast = filter(
+            m -> occursin("Plasticity", string(m[1].file)) || occursin("Plasticity", string(m[2].file)),
+            amb,
+        )
+        @test isempty(plast)
+
+        # every softening combination must dispatch and apply softening at EII > 0
+        sC = LinearSoftening(0.0e0, 1.0e7, 0.0e0, 1.0e0)
+        sϕ = LinearSoftening(15.0e0, 30.0e0, 0.0e0, 1.0e0)
+        sΨ = LinearSoftening(0.0e0, 20.0e0, 0.0e0, 1.0e0)
+        for p in (
+                DruckerPrager(; softening_C = sC),
+                DruckerPrager(; softening_ϕ = sϕ),
+                DruckerPrager(; softening_ϕ = sϕ, softening_C = sC),
+                DruckerPrager_regularised(; softening_C = sC),
+                DruckerPrager_regularised(; softening_ϕ = sϕ),
+                DruckerPragerCap(; Ψ = 20.0, softening_C = sC),
+                DruckerPragerCap(; Ψ = 20.0, softening_ϕ = sϕ, softening_Ψ = sΨ),
+                DruckerPragerCap(; Ψ = 20.0, softening_ϕ = sϕ, softening_C = sC, softening_Ψ = sΨ),
+            )
+            F0 = compute_yieldfunction(p; P = 1.0e6, τII = 2.0e7, EII = 0.0)
+            F1 = compute_yieldfunction(p; P = 1.0e6, τII = 2.0e7, EII = 1.0)
+            @test isfinite(F0) && isfinite(F1)
+        end
+    end
+
 end

--- a/test/test_Softening.jl
+++ b/test/test_Softening.jl
@@ -111,4 +111,36 @@ using GeoParams, Test
 
     @test ds_nd.εref.val == 0.1
 
+    # the stored slope must carry units and be rescaled along with min/max values
+    @test isdimensional(ls.slope)
+    @test ls_nd.slope.val ≈ 0.1
+
+    # evaluation must be consistent across unit systems (regression for unscaled slope)
+    char_stress = 1.0e7 # 10 MPa
+    @test ls_nd(0.25, ls_nd.max_value.val) ≈ ls(0.25, ustrip(Coh)) / char_stress
+
+    # evaluation for softening ranges other than (lo, hi) = (0, 1)
+    @test ls(0.0, 1.0e6) ≈ 1.0e6
+    @test ls(0.25, 1.0e6) ≈ 0.75e6
+    @test ls(0.5, 1.0e6) ≈ 0.5e6
+
+    # softening nested in a plastic element must survive nondimensionalization
+    p_lin = DruckerPrager_regularised(; softening_C = LinearSoftening(5.0e6Pa, 1.0e7Pa, 0.0, 1.0), C = 1.0e7Pa, ϕ = 30.0, η_vp = 1.0e20Pa * s)
+    p_lin_nd = nondimensionalize(p_lin, CharDim)
+    for EII in (0.0, 0.5, 1.0)
+        F_dim = compute_yieldfunction(p_lin; P = 2.0e8, τII = 1.2e8, EII = EII)
+        F_nd = compute_yieldfunction(p_lin_nd; P = 2.0e8 / char_stress, τII = 1.2e8 / char_stress, EII = EII)
+        @test F_dim / char_stress ≈ F_nd
+    end
+
+    p_cap = DruckerPragerCap(; softening_C = NonLinearSoftening(; ξ₀ = 1.5e7Pa, Δ = 7.5e6Pa), C = 1.5e7Pa, ϕ = 30.0, η_vp = 1.0e19Pa * s, pT = -1.5e6Pa, Ψ = 15.0)
+    p_cap_nd = nondimensionalize(p_cap, CharDim)
+    @test p_cap_nd.softening_C.ξ₀.val ≈ 1.5
+    @test p_cap_nd.softening_C.Δ.val ≈ 0.75
+    for EII in (0.0, 0.5, 2.0)
+        F_dim = compute_yieldfunction(p_cap; P = 1.5e8, τII = 9.0e7, EII = EII)
+        F_nd = compute_yieldfunction(p_cap_nd; P = 1.5e8 / char_stress, τII = 9.0e7 / char_stress, EII = EII)
+        @test F_dim / char_stress ≈ F_nd
+    end
+
 end

--- a/test/test_Softening.jl
+++ b/test/test_Softening.jl
@@ -143,4 +143,22 @@ using GeoParams, Test
         @test F_dim / char_stress ≈ F_nd
     end
 
+    # MPa-declared parameters must nondimensionalize identically to Pa-declared ones
+    p_MPa = DruckerPragerCap(; softening_C = NonLinearSoftening(; ξ₀ = 15.0MPa, Δ = 7.5MPa), C = 15.0MPa, ϕ = 30.0, η_vp = 1.0e19Pa * s, pT = -1.5MPa, Ψ = 15.0)
+    p_MPa_nd = nondimensionalize(p_MPa, CharDim)
+    @test p_MPa_nd.C.val ≈ p_cap_nd.C.val
+    @test p_MPa_nd.pT.val ≈ p_cap_nd.pT.val
+    @test p_MPa_nd.softening_C.ξ₀.val ≈ p_cap_nd.softening_C.ξ₀.val
+    @test p_MPa_nd.softening_C.Δ.val ≈ p_cap_nd.softening_C.Δ.val
+    for EII in (0.0, 0.5, 2.0)
+        F_Pa = compute_yieldfunction(p_cap_nd; P = 15.0, τII = 9.0, EII = EII)
+        F_MPa = compute_yieldfunction(p_MPa_nd; P = 15.0, τII = 9.0, EII = EII)
+        @test F_Pa ≈ F_MPa
+    end
+
+    # partial positional construction must not stack-overflow
+    nls2 = NonLinearSoftening(30.0, 10.0)
+    @test nls2.ξ₀.val == 30.0
+    @test nls2.Δ.val == 10.0
+
 end


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other, please explain

**Describe it in more detail below:**
While running JustRelax models in nondimensional form, @albert-de-montserrat  and I observed some weird cases where the plastic return mapping would not work although everything was properly nondimensionalised in the script. If the same script was run in dimensional form, the return mapping worked. 

This PR addresses these issues. Note that the src code audit and tests were performed and added by Claude Opus 4.8 and verified by me. 

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests were added, or old tests were updated
- [ ] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [Runic Style](https://github.com/fredrikekre/Runic.jl)
