### PR TITLE
[BUGFIX] Fix 2D ∂Q∂τxx and ∂Q∂τyy to account for the τzz incompressibility constraint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoParams"
 uuid = "e018b62d-d9de-4a26-8697-af89c310ae38"
 authors = ["Boris Kaus <kaus@uni-mainz.de>, Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.16"
+version = "0.7.17"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Plasticity/DruckerPrager.jl
+++ b/src/Plasticity/DruckerPrager.jl
@@ -160,8 +160,8 @@ for t in (:NTuple, :SVector)
         ∂Q∂τxz(p::DruckerPrager, τij::$(t){6, T}) where {T} = τij[5] / second_invariant(τij)
         ∂Q∂τxy(p::DruckerPrager, τij::$(t){6, T}) where {T} = τij[6] / second_invariant(τij)
         ## 2D derivatives
-        ∂Q∂τxx(p::DruckerPrager, τij::$(t){3, T}) where {T} = 0.5 * τij[1] / second_invariant(τij)
-        ∂Q∂τyy(p::DruckerPrager, τij::$(t){3, T}) where {T} = 0.5 * τij[2] / second_invariant(τij)
+        ∂Q∂τxx(p::DruckerPrager, τij::$(t){3, T}) where {T} = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
+        ∂Q∂τyy(p::DruckerPrager, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
         ∂Q∂τxy(p::DruckerPrager, τij::$(t){3, T}) where {T} = τij[3] / second_invariant(τij)
     end
 end

--- a/src/Plasticity/DruckerPragerCap.jl
+++ b/src/Plasticity/DruckerPragerCap.jl
@@ -523,16 +523,16 @@ for t in (:NTuple, :SVector)
         end
 
         # --- 2D (3-component Voigt) ---
-        # diagonal components: ∂Q/∂τij = Aτ * τij / τII
+        # diagonal components: τzz = -τxx - τyy (constraint) adds cross-terms to the gradient
         function ∂Q∂τxx(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}
             τII = second_invariant(τij)
             Aτ = ∂Q∂τII(p, τII; P = P, Pf = Pf, EII = EII, perturbation_C = perturbation_C)
-            return iszero(τII) ? zero(T) : Aτ * τij[1] / τII
+            return iszero(τII) ? zero(T) : Aτ * (τij[1] + 0.5 * τij[2]) / τII
         end
         function ∂Q∂τyy(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}
             τII = second_invariant(τij)
             Aτ = ∂Q∂τII(p, τII; P = P, Pf = Pf, EII = EII, perturbation_C = perturbation_C)
-            return iszero(τII) ? zero(T) : Aτ * τij[2] / τII
+            return iszero(τII) ? zero(T) : Aτ * (0.5 * τij[1] + τij[2]) / τII
         end
         # shear component: ∂Q/∂τij = 2Aτ * τij / τII
         function ∂Q∂τxy(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}

--- a/src/Plasticity/DruckerPrager_regularised.jl
+++ b/src/Plasticity/DruckerPrager_regularised.jl
@@ -166,8 +166,8 @@ for t in (:NTuple, :SVector)
         ∂Q∂τxz(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[5] / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[6] / second_invariant(τij)
         ## 2D derivatives
-        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
-        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[2] + τij[1]) / second_invariant(τij)
+        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
+        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = τij[3] / second_invariant(τij)
     end
 end

--- a/src/Plasticity/DruckerPrager_regularised.jl
+++ b/src/Plasticity/DruckerPrager_regularised.jl
@@ -166,8 +166,8 @@ for t in (:NTuple, :SVector)
         ∂Q∂τxz(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[5] / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[6] / second_invariant(τij)
         ## 2D derivatives
-        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = 0.5 * τij[1] / second_invariant(τij)
-        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = 0.5 * τij[2] / second_invariant(τij)
+        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[2] + τij[1]) / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = τij[3] / second_invariant(τij)
     end
 end

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -429,12 +429,12 @@ using StaticArrays
         @test num_alloc == 0
 
         # Test plastic potential derivatives
-        ## 2D
+        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
         τij = (1.0, 2.0, 3.0)
         τII_test = second_invariant(τij)
         dQτII = ∂Q∂τII(p, τII_test)
-        fxx(τij) = dQτII * τij[1] / second_invariant(τij)
-        fyy(τij) = dQτII * τij[2] / second_invariant(τij)
+        fxx(τij) = dQτII * (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
+        fyy(τij) = dQτII * (0.5 * τij[1] + τij[2]) / second_invariant(τij)
         fxy(τij) = 2 * dQτII * τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -444,10 +444,11 @@ using StaticArrays
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD
+        # using AD — must agree with analytical constrained gradient scaled by Aτ
         Q = second_invariant # where second_invariant is a function
         ad2 = ∂Q∂τ(Q, τij_tuple)
         @test ad2 == (0.5, 0.625, 0.75)
+        @test all(isapprox.(dQτII .* collect(ad2), [out2[1], out2[2], out2[3] / 2]; rtol = 1.0e-5))
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -95,10 +95,10 @@ using StaticArrays
         @test num_alloc == 0
 
         # Test plastic potential derivatives
-        ## 2D
+        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
         τij = (1.0, 2.0, 3.0)
-        fxx(τij) = 0.5 * τij[1] / second_invariant(τij)
-        fyy(τij) = 0.5 * τij[2] / second_invariant(τij)
+        fxx(τij) = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
+        fyy(τij) = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
         fxy(τij) = τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -112,10 +112,11 @@ using StaticArrays
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD
+        # using AD — must agree with the analytical constrained gradient
         Q = second_invariant # where second_invariant is a function
         ad2 = ∂Q∂τ(Q, τij_tuple)
         @test ad2 == (0.5, 0.625, 0.75)
+        @test collect(out1) ≈ collect(ad2)
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
@@ -258,10 +259,10 @@ using StaticArrays
         # @test num_alloc <= 32
 
         # Test plastic potential derivatives
-        ## 2D
+        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
         τij = (1.0, 2.0, 3.0)
-        fxx(τij) = 0.5 * τij[1] / second_invariant(τij)
-        fyy(τij) = 0.5 * τij[2] / second_invariant(τij)
+        fxx(τij) = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
+        fyy(τij) = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
         fxy(τij) = τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -275,10 +276,11 @@ using StaticArrays
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD
+        # using AD — must agree with the analytical constrained gradient
         Q = second_invariant # where second_invariant is a function
         ad2 = ∂Q∂τ(Q, τij_tuple)
         @test ad2 == (0.5, 0.625, 0.75)
+        @test collect(out1) ≈ collect(ad2)
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -607,9 +607,9 @@ using StaticArrays
         @test ∂Q∂τ(Q, [1.0, 2.0, 2.0]) ≈ [1 / 3, 2 / 3, 2 / 3] rtol = 1.0e-9
         # 3-arg (args, kwargs) form + the MaterialParams plasticity dispatch
         τ = @SVector [1.0, 2.0, 3.0]
-        @test ∂Q∂τ(p, τ, (;)) ≈ [0.125, 0.25, 0.75] rtol = 1.0e-9
+        @test ∂Q∂τ(p, τ, (;)) ≈ [0.5, 0.625, 0.75] rtol = 1.0e-9
         mp = SetMaterialParams(; Phase = 1, Plasticity = DruckerPrager(; C = 1.0e6))
-        @test ∂Q∂τ(mp, τ) ≈ [0.125, 0.25, 0.75] rtol = 1.0e-9
+        @test ∂Q∂τ(mp, τ) ≈ [0.5, 0.625, 0.75] rtol = 1.0e-9
     end
 
 end


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

#### Background

The 2D second invariant in GeoParams includes the out-of-plane stress component via the incompressibility constraint `τzz = -τxx - τyy`:

```julia
# doubledot for NTuple{3} / SVector{3}
Azz = -A[1] - A[2]
return (A[1]*B[1] + A[2]*B[2] + Azz*Bzz) + 2*(A[3]*B[3])
```

This means `τII = √(τxx² + τyy² + τxx·τyy + τxy²)` as a function of the three stored components.

#### The bug

The previous `∂Q∂τxx` and `∂Q∂τyy` for the 2D (NTuple{3} / SVector{3}) dispatch used the **unconstrained 3D formula**, treating `τzz` as if it were independent of `τxx` and `τyy`:

```julia
∂Q∂τxx = 0.5 * τxx / τII   # wrong — ignores ∂τzz/∂τxx = -1
∂Q∂τyy = 0.5 * τyy / τII   # wrong — ignores ∂τzz/∂τyy = -1
```

Applying the chain rule through `τzz = -τxx - τyy` gives the correct constrained gradient:

```
∂τII/∂τxx = τxx/(2τII) + τzz/(2τII)·(-1) = (τxx - τzz)/(2τII) = (2τxx + τyy)/(2τII)
∂τII/∂τyy = (τxx + 2τyy)/(2τII)
```

This can be written more compactly as:
```julia
∂Q∂τxx = (τxx + 0.5·τyy) / τII
∂Q∂τyy = (0.5·τxx + τyy) / τII
```

The formula for `∂Q∂τxy` was already correct.

The error can be verified with ForwardDiff on `second_invariant((1,2,3))`:
- Correct (AD): `(0.5, 0.625, 0.75)`
- Old code: `(0.125, 0.25, 0.75)`

#### This PR also fixes

A partial fix was already on this branch (`e7b1eb00`) but had two additional bugs:
1. The 2D methods inside `DruckerPrager.jl` were dispatched on `DruckerPrager_regularised`, a type not yet defined at that point in the load order → compile error.
2. The numerators were swapped: the `τxx` method received the `τyy` formula and vice versa.

Both are corrected here.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests were added, or old tests were updated
- [x] Are all lines covered by test? Code coverage should remain the same or increase
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [Runic Style](https://github.com/fredrikekre/Runic.jl)