### PR TITLE
[ADDITION] Various features from Degruyter & Huber (2014)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -66,6 +66,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 
 [targets]
-test = ["AbstractDifferentiation", "Aqua", "CairoMakie", "ReverseDiff", "Statistics", "Test"]
+test = ["AbstractDifferentiation", "Aqua", "CairoMakie", "ReverseDiff", "Statistics", "Test", "ParallelTestRunner"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoParams"
 uuid = "e018b62d-d9de-4a26-8697-af89c310ae38"
 authors = ["Boris Kaus <kaus@uni-mainz.de>, Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.17"
+version = "0.7.18"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,11 +38,11 @@ makedocs(;
                 "Density" => "man/density.md",
             ],
             "Constitutive Relationships" => Any[
-            "Creep laws" => "man/creeplaws.md",
-            "Custom rheology" => "man/customrheology.md",
-            "Viscosity" => "man/viscosity.md",
-            "Elasticity" => "man/elasticity.md",
-            "Plasticity" => "man/plasticity.md",
+                "Creep laws" => "man/creeplaws.md",
+                "Custom rheology" => "man/customrheology.md",
+                "Viscosity" => "man/viscosity.md",
+                "Elasticity" => "man/elasticity.md",
+                "Plasticity" => "man/plasticity.md",
             ],
             "Chemical Diffusion" => Any[
                 "Computational routines" => "man/chemicaldiffusion.md",

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -595,7 +595,6 @@ Set a density depending on the oxide composition after the python script by Iaco
 
 ## References
 - Iacovino K & Till C (2019). DensityX: A program for calculating the densities of magmatic liquids up to 1,627 °C and 30 kbar. Volcanica 2(1), p 1-10. [doi:10.30909/vol.02.01.0110](https://dx.doi.org/10.30909/vol.02.01.0110)
-
 """
 struct Melt_DensityX{T, T1, T2, T3, T4, T5, T6, U, U1, U2, U3, U4, U5} <: AbstractDensity{T}
     oxd_wt::NTuple{9, T} # Oxide weight percent

--- a/src/Density/Density.jl
+++ b/src/Density/Density.jl
@@ -9,6 +9,7 @@ using Parameters, Unitful, LaTeXStrings, MuladdMacro
 using ..Units
 using ..PhaseDiagrams
 using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct, @extractors, add_extractor_functions, AbstractPhaseDiagramsStruct
+using GeoParams: fastpow, pow_check, @pow
 import ..Units: isdimensional
 using ..MaterialParameters: No_MaterialParam, MaterialParamsInfo
 import Base.show, GeoParams.param_info
@@ -33,6 +34,9 @@ export compute_density, # calculation routines
     MeltDependent_Density, # Melt dependent density
     BubbleFlow_Density, # Bubble flow density
     GasPyroclast_Density, # Gas-Pyroclast mixture density
+    RedlichKwong_Density, # Modified Redlich-Kwong gas EOS (Huber et al. 2010)
+    IdealGas_Density, # Ideal-gas EOS
+    ThreePhase_Density, # melt + crystal + gas mixture density
     Melt_DensityX,
     get_α
 
@@ -418,6 +422,164 @@ end
 function show(io::IO, g::GasPyroclast_Density)
     return print(io, "Gas-Pyroclast mixture density: ρ = ρgas*δ + ρmelt*(1-β); ρmelt=$(g.ρmelt); ρgas=$(g.ρgas); δ=$(UnitValue(g.δ)); β=$(UnitValue(g.β))")
 end
+
+# Gas equation-of-state densities -----------------------------------------
+"""
+    RedlichKwong_Density(; coeffs=(-112.528, 127.811, 112.04), T0=273.15K, Tref=1K, Pref=1e5Pa, ρref=1e3kg/m^3)
+
+Modified Redlich–Kwong gas density of Huber et al. (2010), as used by Degruyter
+& Huber (2014). Fitted for H2O gas over roughly ``873 < T < 1173`` K and
+``30 < P < 400`` MPa:
+```math
+    \\rho_g = \\rho_{ref}\\left(a_1\\,\\tau^{-0.381} + a_2\\,\\varpi^{-1.135}
+             + a_3\\,\\tau^{-0.411}\\varpi^{0.033}\\right),
+    \\quad \\tau = \\frac{T - T_0}{T_{ref}},\\ \\varpi = \\frac{P}{P_{ref}}
+```
+The fit's specific units (°C, bar) enter through the reference quantities: with
+`T0=273.15K`, `Tref=1K` the group ``\\tau`` equals ``T`` in °C, and with
+`Pref=1e5Pa` (1 bar) ``\\varpi`` equals ``P`` in bar. Because ``\\tau`` and
+``\\varpi`` are ratios of like-dimensioned quantities, the expression is
+dimensionally homogeneous and nondimensionalizes cleanly: only the reference
+`GeoUnit`s scale, the fitted dimensionless `coeffs` do not. The parameterisation
+ignores gas composition (pseudo-pure H2O), matching the reference.
+
+# References
+- Huber, C., Bachmann, O., Dufek, J. (2010), The limitations of melting on the reactivation of silicic mushes, JVGR 195, 97-105, https://doi.org/10.1016/j.jvolgeores.2010.06.006
+- Degruyter, W., Huber, C. (2014), A model for the eruption frequency of upper crustal silicic magma chambers, EPSL 403, 117-130, https://doi.org/10.1016/j.epsl.2014.06.047
+"""
+struct RedlichKwong_Density{T, U1, U2, U3} <: AbstractDensity{T}
+    coeffs::NTuple{3, T}      # dimensionless fit coefficients (Huber et al. 2010)
+    T0::GeoUnit{T, U1}        # Kelvin -> Celsius reference offset
+    Tref::GeoUnit{T, U1}      # temperature scale of the fit (1 K)
+    Pref::GeoUnit{T, U2}      # pressure scale of the fit (1 bar)
+    ρref::GeoUnit{T, U3}      # density scale of the fit (1e3 kg/m³)
+
+    function RedlichKwong_Density(;
+            coeffs = (-112.528, 127.811, 112.04),
+            T0 = 273.15K, Tref = 1.0K, Pref = 1.0e5Pa, ρref = 1.0e3kg / m^3
+        )
+        T0U = convert(GeoUnit, T0)
+        TrefU = convert(GeoUnit, Tref)
+        PrefU = convert(GeoUnit, Pref)
+        ρrefU = convert(GeoUnit, ρref)
+        T = typeof(ρrefU).types[1]
+        U1 = typeof(T0U).types[2]
+        U2 = typeof(PrefU).types[2]
+        U3 = typeof(ρrefU).types[2]
+        return new{T, U1, U2, U3}(T.(coeffs), T0U, TrefU, PrefU, ρrefU)
+    end
+    RedlichKwong_Density(coeffs, T0, Tref, Pref, ρref) = RedlichKwong_Density(; coeffs, T0, Tref, Pref, ρref)
+end
+isdimensional(s::RedlichKwong_Density) = isdimensional(s.ρref)
+
+function param_info(s::RedlichKwong_Density)
+    return MaterialParamsInfo(; Equation = L"\rho_g = \rho_{ref}(a_1 \tau^{-0.381} + a_2 \varpi^{-1.135} + a_3 \tau^{-0.411} \varpi^{0.033})")
+end
+
+@inline function (rho::RedlichKwong_Density)(; P = 0.0e0, T = 0.0e0, kwargs...)
+    a1, a2, a3 = rho.coeffs
+    if P isa Quantity
+        @unpack_units T0, Tref, Pref, ρref = rho
+    else
+        @unpack_val T0, Tref, Pref, ρref = rho
+    end
+    τ = (T - T0) / Tref            # ∝ T in °C
+    ω = P / Pref                   # ∝ P in bar
+    return @muladd @pow (a1 * τ^(-0.381) + a2 * ω^(-1.135) + a3 * τ^(-0.411) * ω^0.033) * ρref
+end
+@inline (s::RedlichKwong_Density)(args) = s(; args...)
+@inline compute_density(s::RedlichKwong_Density, args) = s(args)
+
+function show(io::IO, g::RedlichKwong_Density)
+    return print(io, "Redlich-Kwong gas density (Huber et al. 2010): ρg = ρref*(a1*τ^-0.381 + a2*ω^-1.135 + a3*τ^-0.411*ω^0.033)")
+end
+
+"""
+    IdealGas_Density(; Rs=461.5J/kg/K)
+
+Ideal-gas density
+```math
+    \\rho_g = \\frac{P}{R_s T}
+```
+with specific gas constant `Rs` (default: water vapor, ``R/M_w = 8.314/0.01802``).
+Unlike [`RedlichKwong_Density`](@ref) this is dimensionally homogeneous, so it
+nondimensionalizes cleanly and serves as the analytic derivative check for the
+Redlich–Kwong fit.
+"""
+@with_kw_noshow struct IdealGas_Density{_T, U1} <: AbstractDensity{_T}
+    Rs::GeoUnit{_T, U1} = 461.5J / kg / K   # specific gas constant
+end
+IdealGas_Density(args...) = IdealGas_Density(convert.(GeoUnit, args)...)
+isdimensional(s::IdealGas_Density) = isdimensional(s.Rs)
+
+function param_info(s::IdealGas_Density)
+    return MaterialParamsInfo(; Equation = L"\rho_g = P/(R_s T)")
+end
+
+@inline function (rho::IdealGas_Density)(; P = 0.0e0, T = 0.0e0, kwargs...)
+    if P isa Quantity
+        @unpack_units Rs = rho
+    else
+        @unpack_val Rs = rho
+    end
+    return P / (Rs * T)
+end
+@inline (s::IdealGas_Density)(args) = s(; args...)
+@inline compute_density(s::IdealGas_Density, args) = s(args)
+
+function show(io::IO, g::IdealGas_Density)
+    return print(io, "Ideal-gas density: ρg = P/(Rs*T); Rs=$(UnitValue(g.Rs))")
+end
+
+# Three-phase (melt + crystal + gas) mixture density ----------------------
+"""
+    ThreePhase_Density(; ρmelt=ConstantDensity(ρ=2300kg/m^3), ρx=ConstantDensity(ρ=2600kg/m^3), ρgas=RedlichKwong_Density(), ρ=2400kg/m^3)
+
+Volume-fraction mixture density of a melt + crystal + gas magma (Degruyter &
+Huber 2014):
+```math
+    \\rho = \\varepsilon_m \\rho_m + \\varepsilon_g \\rho_g + \\varepsilon_x \\rho_x,
+    \\qquad \\varepsilon_m = 1 - \\varepsilon_x - \\varepsilon_g
+```
+The gas and crystal volume fractions `ϕ_gas`, `ϕ_x` are inputs (from the solver's
+ODE state / a melting law), passed through `args`; the sub-densities receive the
+same `args` (e.g. `P`, `T`) so an equation-of-state gas density is evaluated in
+place. `ρ` is a dimensional-tracking sentinel.
+
+# Arguments
+- `ρmelt`: melt-phase density
+- `ρx`: crystal-phase density
+- `ρgas`: gas-phase density (e.g. [`RedlichKwong_Density`](@ref))
+
+# References
+- Degruyter, W., Huber, C. (2014), A model for the eruption frequency of upper crustal silicic magma chambers, EPSL 403, 117-130, https://doi.org/10.1016/j.epsl.2014.06.047
+"""
+@with_kw_noshow struct ThreePhase_Density{_T, U, S1 <: AbstractDensity, S2 <: AbstractDensity, S3 <: AbstractDensity} <: AbstractDensity{_T}
+    ρmelt::S1 = ConstantDensity(ρ = 2300kg / m^3)   # melt
+    ρx::S2 = ConstantDensity(ρ = 2600kg / m^3)      # crystals
+    ρgas::S3 = RedlichKwong_Density()               # gas
+    ρ::GeoUnit{_T, U} = 2400.0kg / m^3              # dimensional-tracking sentinel
+end
+ThreePhase_Density(args...) = ThreePhase_Density(args[1], args[2], args[3], convert.(GeoUnit, args[4:end])...)
+isdimensional(s::ThreePhase_Density) = isdimensional(s.ρ)
+
+function param_info(s::ThreePhase_Density)
+    return MaterialParamsInfo(; Equation = L"\rho = \varepsilon_m \rho_m + \varepsilon_g \rho_g + \varepsilon_x \rho_x")
+end
+
+@inline function (rho::ThreePhase_Density)(; ϕ_gas = 0.0e0, ϕ_x = 0.0e0, kwargs...)
+    ρm = compute_density(rho.ρmelt, kwargs)
+    ρx = compute_density(rho.ρx, kwargs)
+    ρg = compute_density(rho.ρgas, kwargs)   # kwargs carries P,T for an EOS gas density
+    ϕ_m = 1 - ϕ_x - ϕ_gas
+    return @muladd ϕ_m * ρm + ϕ_gas * ρg + ϕ_x * ρx
+end
+@inline (s::ThreePhase_Density)(args) = s(; args...)
+@inline compute_density(s::ThreePhase_Density, args) = s(args)
+
+function show(io::IO, g::ThreePhase_Density)
+    return print(io, "Three-phase density: ρ = ϕ_m*ρmelt + ϕ_gas*ρgas + ϕ_x*ρx; ρmelt=$(g.ρmelt); ρx=$(g.ρx); ρgas=$(g.ρgas)")
+end
 #-------------------------------------------------------------------------
 # Melt_DensityX density depending on Oxide composition
 """
@@ -686,7 +848,7 @@ This assumes that the `PhaseRatio` of every point is specified as an Integer in 
 @inline compute_density_ratio(args::Vararg{Any, N}) where {N} = compute_param_times_frac(compute_density, args...)
 
 # extractor methods
-for type in (ConstantDensity, PT_Density, Compressible_Density, T_Density, MeltDependent_Density, Vector_Density, BubbleFlow_Density, GasPyroclast_Density, Melt_DensityX)
+for type in (ConstantDensity, PT_Density, Compressible_Density, T_Density, MeltDependent_Density, Vector_Density, BubbleFlow_Density, GasPyroclast_Density, RedlichKwong_Density, IdealGas_Density, ThreePhase_Density, Melt_DensityX)
     @extractors(type, :Density)
 end
 

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -391,6 +391,7 @@ module GeoParams
     using .MaterialParameters.Solubility
     export compute_dissolved,
         compute_dissolved!,
+        compute_dissolved_ratio,
         ∂dissolved_∂P,
         ∂dissolved_∂T,
         ∂dissolved_∂Xco2,

--- a/src/GeoParams.jl
+++ b/src/GeoParams.jl
@@ -142,6 +142,9 @@ module GeoParams
         MeltDependent_Density,
         BubbleFlow_Density,
         GasPyroclast_Density,
+        RedlichKwong_Density,
+        IdealGas_Density,
+        ThreePhase_Density,
         Melt_DensityX,
         compute_density_ratio
 
@@ -369,6 +372,7 @@ module GeoParams
         MeltingParam_5thOrder,
         MeltingParam_Quadratic,
         MeltingParam_Assimilation,
+        MeltingParam_Volatile,
         Vector_MeltingParam,
         SmoothMelting
 
@@ -383,6 +387,19 @@ module GeoParams
         HazenPermeability,
         PowerLawPermeability,
         CarmanKozenyPermeability
+
+    using .MaterialParameters.Solubility
+    export compute_dissolved,
+        compute_dissolved!,
+        ∂dissolved_∂P,
+        ∂dissolved_∂T,
+        ∂dissolved_∂Xco2,
+        AbstractSolubility,
+        Liu2005_Solubility,
+        Mafic_Solubility,
+        GasMixture,
+        compute_gas_heatcapacity,
+        effective_molar_mass
 
     include("Traits/rheology.jl")
     export RheologyTrait

--- a/src/MaterialParameters.jl
+++ b/src/MaterialParameters.jl
@@ -54,8 +54,10 @@ module MaterialParameters
     include("./Energy/RadioactiveHeat.jl")
     include("./Energy/Shearheating.jl")
     include("./SeismicVelocity/SeismicVelocity.jl")
+    include("./Solubility/Solubility.jl")
 
     using .Density: AbstractDensity, ConduitDensity
+    using .Solubility: AbstractSolubility
     using .ConstitutiveRelationships: print_rheology_matrix
 
 
@@ -81,6 +83,7 @@ module MaterialParameters
             Vpermeability <: Tuple,
             Vmelting <: Tuple,
             Vseismvel <: Tuple,
+            Vsolubility <: Tuple,
         } <: AbstractMaterialParamsStruct
         Name::Ptr{UInt8}                   #  Phase name
         Phase::Int64 = 1                   #  Number of the phase (optional)
@@ -100,6 +103,7 @@ module MaterialParameters
         Permeability::Vpermeability = ()   #  Permeability
         Melting::Vmelting = ()             #  Melting model
         SeismicVelocity::Vseismvel = ()    #  Seismic velocity
+        Solubility::Vsolubility = ()       #  Volatile solubility (dissolved H2O/CO2)
     end
 
     Adapt.@adapt_structure MaterialParams
@@ -121,6 +125,7 @@ module MaterialParameters
                             Permeability        =   nothing,
                             Melting             =   nothing,
                             SeismicVelocity     =   nothing,
+                            Solubility          =   nothing,
                             CharDim::GeoUnits   =   nothing)
 
     Sets material parameters for a given phase.
@@ -210,6 +215,7 @@ module MaterialParameters
             Permeability = nothing,
             Melting = nothing,
             SeismicVelocity = nothing,
+            Solubility = nothing,
             CharDim = nothing,
         )
         return SetMaterialParams(
@@ -230,6 +236,7 @@ module MaterialParameters
             ConvField(Permeability, :Permeability; maxAllowedFields = 1),
             ConvField(Melting, :Melting; maxAllowedFields = 1),
             ConvField(SeismicVelocity, :SeismicVelocity; maxAllowedFields = 1),
+            ConvField(Solubility, :Solubility; maxAllowedFields = 1),
             CharDim,
         )
     end
@@ -252,6 +259,7 @@ module MaterialParameters
             Permeability,
             Melting,
             SeismicVelocity,
+            Solubility,
             CharDim,
         )
 
@@ -275,6 +283,7 @@ module MaterialParameters
             Permeability,
             Melting,
             SeismicVelocity,
+            Solubility,
         )
 
         # [optionally] non-dimensionalize the struct

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -3,7 +3,8 @@ module MeltingParam
 # If you want to add a new method here, feel free to do so.
 # Remember to also export the function name in GeoParams.jl (in addition to here)
 
-using Parameters, LaTeXStrings, Unitful, ForwardDiff
+using Parameters, LaTeXStrings, Unitful, ForwardDiff, MuladdMacro
+using SpecialFunctions: erfc
 using ..Units
 using GeoParams:
     AbstractMaterialParam, AbstractPhaseDiagramsStruct, AbstractMaterialParamsStruct
@@ -25,6 +26,7 @@ export compute_meltfraction,
     MeltingParam_5thOrder,
     MeltingParam_Quadratic,
     MeltingParam_Assimilation,
+    MeltingParam_Volatile,
     Vector_MeltingParam,
     SmoothMelting
 
@@ -667,6 +669,103 @@ function show(io::IO, g::SmoothMelting)
 end
 #-------------------------------------------------------------------------
 
+# MeltingParam_Volatile  -------------------------------------------------
+"""
+    MeltingParam_Volatile(; a_coeffs, b_coeffs, c_coeffs, T0=273K, Tref=1K, Pref=1e6Pa)
+
+Volatile-dependent silicic melting parameterisation used by Degruyter & Huber
+(2014). The crystal fraction follows a complementary error function whose
+amplitude `a`, width `b`, and centre `c` depend on the dissolved water and CO2
+contents and pressure:
+```math
+    \\varepsilon_x = a\\,\\mathrm{erfc}\\!\\big(b\\,(T_C - c)\\big),
+    \\qquad \\phi = 1 - \\varepsilon_x
+```
+with ``T_C = (T - T_0)/T_{ref}`` (numerically °C) and each of ``a, b, c`` a
+quadratic polynomial in ``x = 100\\,m_{H_2O}``, ``y = 100\\,m_{CO_2}`` (dissolved
+mass fractions, in wt%) and ``z = P/P_{ref}`` (numerically MPa). Dissolved water
+depresses the liquidus, so more water shifts the curve to lower temperature —
+the crystallization→exsolution (second-boiling) feedback of the D&H model. The
+returned quantity is the **melt fraction** ``\\phi``; the exsolved-gas fraction
+``\\varepsilon_g`` is a solver state and is not subtracted here.
+
+The dimensionless polynomial coefficients are stored as plain `NTuple`s; only the
+reference scales `T0`, `Tref`, `Pref` are `GeoUnit`s, so the parameterisation
+nondimensionalizes. Dissolved contents `mH2O`, `mCO2` are dimensionless and pass
+through `args`.
+
+# References
+- Degruyter, W., Huber, C. (2014), A model for the eruption frequency of upper crustal silicic magma chambers, EPSL 403, 117-130, https://doi.org/10.1016/j.epsl.2014.06.047
+"""
+struct MeltingParam_Volatile{T, U1, U2} <: AbstractMeltingParam{T}
+    a_coeffs::NTuple{10, T}   # erfc amplitude polynomial in (x, y, z)
+    b_coeffs::NTuple{10, T}   # erfc width polynomial
+    c_coeffs::NTuple{10, T}   # erfc centre polynomial (°C)
+    T0::GeoUnit{T, U1}        # Kelvin -> Celsius reference offset (273 K)
+    Tref::GeoUnit{T, U1}      # temperature scale of the fit (1 K)
+    Pref::GeoUnit{T, U2}      # pressure scale of the fit (1 MPa)
+
+    function MeltingParam_Volatile(;
+            a_coeffs = (0.36, -0.02, -0.06, 8.6e-4, 0.0024, 6.27e-5, 3.57e-5, -0.0026, 0.003, -1.16e-6),
+            b_coeffs = (0.0071, 0.0049, 0.0043, -4.08e-5, -7.85e-4, -1.3e-5, 3.97e-6, 6.29e-4, -0.0025, 8.51e-8),
+            c_coeffs = (863.09, -36.9, 48.81, -0.17, -1.52, -0.04, -0.04, 4.57, -7.79, 4.65e-4),
+            T0 = 273.0K, Tref = 1.0K, Pref = 1.0e6Pa
+        )
+        T0U = convert(GeoUnit, T0)
+        TrefU = convert(GeoUnit, Tref)
+        PrefU = convert(GeoUnit, Pref)
+        T = typeof(PrefU).types[1]
+        U1 = typeof(T0U).types[2]
+        U2 = typeof(PrefU).types[2]
+        return new{T, U1, U2}(T.(a_coeffs), T.(b_coeffs), T.(c_coeffs), T0U, TrefU, PrefU)
+    end
+    MeltingParam_Volatile(a_coeffs, b_coeffs, c_coeffs, T0, Tref, Pref) =
+        MeltingParam_Volatile(; a_coeffs, b_coeffs, c_coeffs, T0, Tref, Pref)
+end
+
+function param_info(s::MeltingParam_Volatile)
+    return MaterialParamsInfo(; Equation = L"\phi = 1 - a\,\mathrm{erfc}(b(T_C - c))")
+end
+
+# quadratic in (x, y, z): 1, x, y, z, xy, xz, yz, x², y², z²
+@inline function _volatile_poly(k::NTuple{10}, x, y, z)
+    return @muladd k[1] + k[2] * x + k[3] * y + k[4] * z + k[5] * x * y + k[6] * x * z +
+        k[7] * y * z + k[8] * x^2 + k[9] * y^2 + k[10] * z^2
+end
+
+@inline function (p::MeltingParam_Volatile)(; T, P = 0.0e0, mH2O = 0.0e0, mCO2 = 0.0e0, kwargs...)
+    if T isa Quantity
+        @unpack_units T0, Tref, Pref = p
+    else
+        @unpack_val T0, Tref, Pref = p
+    end
+    x = 100 * mH2O            # wt%
+    y = 100 * mCO2            # wt%
+    z = P / Pref              # ∝ P in MPa
+    TC = (T - T0) / Tref      # ∝ T in °C
+    a = _volatile_poly(p.a_coeffs, x, y, z)
+    b = _volatile_poly(p.b_coeffs, x, y, z)
+    c = _volatile_poly(p.c_coeffs, x, y, z)
+    εx = a * erfc(b * (TC - c))
+    return 1 - εx
+end
+
+@inline function compute_dϕdT(p::MeltingParam_Volatile; T, P = 0.0e0, mH2O = 0.0e0, mCO2 = 0.0e0, kwargs...)
+    return ForwardDiff.derivative(t -> p(; T = t, P, mH2O, mCO2), T)
+end
+
+function compute_dϕdT!(dϕdT::AbstractArray, p::MeltingParam_Volatile; T::AbstractArray, kwargs...)
+    for i in eachindex(T)
+        dϕdT[i] = compute_dϕdT(p; T = T[i])
+    end
+    return nothing
+end
+
+function show(io::IO, g::MeltingParam_Volatile)
+    return print(io, "Volatile-dependent silicic melting (Degruyter & Huber 2014): ϕ = 1 - a*erfc(b*(T_C - c))")
+end
+#-------------------------------------------------------------------------
+
 """
     compute_meltfraction(P,T, p::AbstractPhaseDiagramsStruct)
 
@@ -734,6 +833,7 @@ for myType in (
         :MeltingParam_4thOrder,
         :MeltingParam_Quadratic,
         :MeltingParam_Assimilation,
+        :MeltingParam_Volatile,
         :Vector_MeltingParam,
         :SmoothMelting,
     )

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -755,8 +755,8 @@ end
 end
 
 function compute_dϕdT!(dϕdT::AbstractArray, p::MeltingParam_Volatile; T::AbstractArray, kwargs...)
-    for i in eachindex(T)
-        dϕdT[i] = compute_dϕdT(p; T = T[i])
+    for i in eachindex(dϕdT, T)
+        dϕdT[i] = compute_dϕdT(p; T = T[i], kwargs...)
     end
     return nothing
 end

--- a/src/MeltFraction/MeltingParameterization.jl
+++ b/src/MeltFraction/MeltingParameterization.jl
@@ -729,8 +729,10 @@ end
 
 # quadratic in (x, y, z): 1, x, y, z, xy, xz, yz, x², y², z²
 @inline function _volatile_poly(k::NTuple{10}, x, y, z)
-    return @muladd k[1] + k[2] * x + k[3] * y + k[4] * z + k[5] * x * y + k[6] * x * z +
-        k[7] * y * z + k[8] * x^2 + k[9] * y^2 + k[10] * z^2
+ return @muladd k[1] +
+        x * (k[2] + k[8] * x + k[5] * y + k[6] * z) +
+        y * (k[3] + k[9] * y + k[7] * z) +
+        z * (k[4] + k[10] * z)
 end
 
 @inline function (p::MeltingParam_Volatile)(; T, P = 0.0e0, mH2O = 0.0e0, mCO2 = 0.0e0, kwargs...)

--- a/src/Solubility/Solubility.jl
+++ b/src/Solubility/Solubility.jl
@@ -1,0 +1,318 @@
+module Solubility
+
+# Coupled H2O–CO2 volatile solubility (dissolved-content) closures for
+# Degruyter & Huber (2014)-type magma-chamber models. Each closure returns
+# *both* dissolved H2O and dissolved CO2 mass fractions at a point, because the
+# two share the partial pressures Pw = P(1-X_co2), Pc = P·X_co2.
+#
+# The empirical fits are in specific units (MPa, K/°C). Following the package
+# convention (see GiordanoMeltViscosity), the dimensionless fit coefficients are
+# stored as a plain NTuple, while the dimensional reference quantities that set
+# those units are GeoUnit fields; the closures are written in terms of the
+# dimensionless groups P/Pref, (T-T0)/Tref, Tref/T, so they nondimensionalize.
+
+using Parameters, Unitful, LaTeXStrings, MuladdMacro
+using ForwardDiff, StaticArrays
+using ..Units
+using GeoParams: AbstractMaterialParam, AbstractMaterialParamsStruct
+using GeoParams: fastpow, pow_check, @pow
+import ..Units: isdimensional
+using ..MaterialParameters: No_MaterialParam, MaterialParamsInfo
+import Base.show, GeoParams.param_info
+
+include("../Computations.jl")
+
+abstract type AbstractSolubility{T} <: AbstractMaterialParam end
+
+export compute_dissolved,           # (m_h2o, m_co2) mass fractions
+    compute_dissolved!,             # in-place, fills two arrays
+    ∂dissolved_∂P,                  # ForwardDiff partials, both outputs
+    ∂dissolved_∂T,
+    ∂dissolved_∂Xco2,
+    param_info,
+    AbstractSolubility,
+    Liu2005_Solubility,             # silicic (rhyolite)
+    Mafic_Solubility,               # mafic (basalt), CO2 block still Liu rhyolite
+    GasMixture,                     # H2O-CO2 gas-mixture properties
+    compute_gas_heatcapacity,       # mass-weighted specific heat c_g(X_co2)
+    effective_molar_mass            # m_g(X_co2)
+
+# Empty routine when no solubility is defined
+compute_dissolved(::No_MaterialParam{_T}; kwargs...) where {_T} = (zero(_T), zero(_T))
+
+# Liu et al. (2005) — silicic ------------------------------------------------
+"""
+    Liu2005_Solubility(; coeffs=(b1..b6, c1..c4), Pref=1MPa, Tref=1K)
+
+Coupled H2O–CO2 solubility for silicic (rhyolite) melt after Liu et al. (2005),
+as used by Degruyter & Huber (2014). [`compute_dissolved`](@ref) returns the
+dissolved H2O and CO2 mass fractions of the melt as a function of pressure,
+temperature, and the CO2 mole fraction of the gas `X_co2`:
+```math
+    m_{H_2O} = (b_1 P_w^{1/2} + b_2 P_w + b_3 P_w^{3/2})\\frac{T_{ref}}{T}
+             + b_4 P_w^{3/2} + P_c(b_5 P_w^{1/2} + b_6 P_w)
+```
+```math
+    m_{CO_2} = P_c(c_1 + c_2 P_w)\\frac{T_{ref}}{T} + P_c(c_3 P_w^{1/2} + c_4 P_w^{3/2})
+```
+with the dimensionless partial pressures ``P_w = P(1-X_{co2})/P_{ref}`` and
+``P_c = P X_{co2}/P_{ref}``. With `Pref=1MPa`, `Tref=1K` these equal the reference
+partial pressures in MPa and reproduce the Liu (2005) numbers; because they are
+ratios of like-dimensioned quantities, the closure is dimensionally homogeneous
+and nondimensionalizes cleanly. The fitted `coeffs` are dimensionless; `isdimensional`
+tracks the reference `GeoUnit`s.
+
+# References
+- Liu, Y., Zhang, Y., Behrens, H. (2005), Solubility of H2O in rhyolitic melts at low pressures and a new empirical model for mixed H2O-CO2 solubility, JVGR 143, 219-235, https://doi.org/10.1016/j.jvolgeores.2004.09.019
+- Degruyter, W., Huber, C. (2014), A model for the eruption frequency of upper crustal silicic magma chambers, EPSL 403, 117-130, https://doi.org/10.1016/j.epsl.2014.06.047
+"""
+struct Liu2005_Solubility{T, U1, U2} <: AbstractSolubility{T}
+    coeffs::NTuple{10, T}     # b1..b6 (H2O), c1..c4 (CO2); dimensionless
+    Pref::GeoUnit{T, U1}      # pressure scale of the fit (1 MPa)
+    Tref::GeoUnit{T, U2}      # temperature scale of the fit (1 K)
+
+    function Liu2005_Solubility(;
+            coeffs = (354.94, 9.623, -1.5223, 1.2439e-3, -1.084e-4, -1.362e-5,
+                5668.0, -55.99, 0.4133, 2.041e-3),
+            Pref = 1.0e6Pa, Tref = 1.0K
+        )
+        PrefU = convert(GeoUnit, Pref)
+        TrefU = convert(GeoUnit, Tref)
+        T = typeof(PrefU).types[1]
+        U1 = typeof(PrefU).types[2]
+        U2 = typeof(TrefU).types[2]
+        return new{T, U1, U2}(T.(coeffs), PrefU, TrefU)
+    end
+    Liu2005_Solubility(coeffs, Pref, Tref) = Liu2005_Solubility(; coeffs, Pref, Tref)
+end
+isdimensional(s::Liu2005_Solubility) = isdimensional(s.Pref)
+
+function param_info(s::Liu2005_Solubility)
+    return MaterialParamsInfo(; Equation = L"m_{H_2O},\ m_{CO_2} = f_{Liu2005}(P, T, X_{co2})")
+end
+
+"""
+    compute_dissolved(s::AbstractSolubility, P, T, X_co2) -> (m_h2o, m_co2)
+
+Dissolved H2O and CO2 mass fractions of the melt (`P` in Pa, `T` in K, `X_co2`
+the CO2 mole fraction of the gas). Also callable as `compute_dissolved(s; P, T,
+X_co2)` and `compute_dissolved(s, args::NamedTuple)`.
+"""
+@inline function compute_dissolved(s::Liu2005_Solubility, P, T, X_co2)
+    b1, b2, b3, b4, b5, b6, c1, c2, c3, c4 = s.coeffs
+    if P isa Quantity
+        @unpack_units Pref, Tref = s
+    else
+        @unpack_val Pref, Tref = s
+    end
+    Pw = P * (1 - X_co2) / Pref     # ∝ H2O partial pressure in MPa
+    Pc = P * X_co2 / Pref           # ∝ CO2 partial pressure in MPa
+    Tr = Tref / T                   # ∝ 1/T [K]
+
+    meq = @muladd @pow (b1 * Pw^0.5 + b2 * Pw + b3 * Pw^1.5) * Tr + b4 * Pw^1.5 + Pc * (b5 * Pw^0.5 + b6 * Pw)
+    Cco2 = @muladd @pow Pc * (c1 + c2 * Pw) * Tr + Pc * (c3 * Pw^0.5 + c4 * Pw^1.5)
+
+    return (1.0e-2 * meq, 1.0e-6 * Cco2)   # wt% -> fraction ; ppm -> fraction
+end
+
+function show(io::IO, s::Liu2005_Solubility)
+    return print(io, "Liu et al. (2005) silicic H2O-CO2 solubility")
+end
+
+# Mafic ----------------------------------------------------------------------
+"""
+    Mafic_Solubility(; coeffs=(b1..b10, c1..c4), T0=273.15K, Tref=1K, Pref=1MPa)
+
+Coupled H2O–CO2 solubility for mafic (basalt) melt. Dissolved H2O follows the
+mafic polynomial of the Scholz/Degruyter–Huber reference in the dimensionless
+groups ``T_C = (T-T_0)/T_{ref}`` (numerically °C) and ``P_m = P/P_{ref}``
+(numerically MPa); dissolved CO2 reuses the Liu (2005) rhyolite CO2 block.
+Nondimensionalizes like [`Liu2005_Solubility`](@ref).
+
+# References
+- Degruyter, W., Huber, C. (2014), A model for the eruption frequency of upper crustal silicic magma chambers, EPSL 403, 117-130, https://doi.org/10.1016/j.epsl.2014.06.047
+- Liu, Y., Zhang, Y., Behrens, H. (2005), Solubility of H2O in rhyolitic melts at low pressures and a new empirical model for mixed H2O-CO2 solubility, JVGR 143, 219-235, https://doi.org/10.1016/j.jvolgeores.2004.09.019
+"""
+struct Mafic_Solubility{T, U1, U2} <: AbstractSolubility{T}
+    coeffs::NTuple{14, T}     # b1..b10 (H2O), c1..c4 (CO2); dimensionless
+    T0::GeoUnit{T, U1}        # Kelvin -> Celsius reference offset
+    Tref::GeoUnit{T, U1}      # temperature scale of the fit (1 K), difference and absolute
+    Pref::GeoUnit{T, U2}      # pressure scale of the fit (1 MPa)
+
+    function Mafic_Solubility(;
+            coeffs = (2.99622526644026, 0.00322422830627781, -9.1389095360385,
+                0.0336065247530767, 0.00747236662935722, -0.0000150329805347769,
+                -0.01233608521548, -4.14842647942619e-6, -0.655454303068124,
+                -7.35270395041104e-6, 5668.0, -55.99, 0.4133, 2.041e-3),
+            T0 = 273.15K, Tref = 1.0K, Pref = 1.0e6Pa
+        )
+        T0U = convert(GeoUnit, T0)
+        TrefU = convert(GeoUnit, Tref)
+        PrefU = convert(GeoUnit, Pref)
+        T = typeof(PrefU).types[1]
+        U1 = typeof(T0U).types[2]
+        U2 = typeof(PrefU).types[2]
+        return new{T, U1, U2}(T.(coeffs), T0U, TrefU, PrefU)
+    end
+    Mafic_Solubility(coeffs, T0, Tref, Pref) = Mafic_Solubility(; coeffs, T0, Tref, Pref)
+end
+isdimensional(s::Mafic_Solubility) = isdimensional(s.Pref)
+
+function param_info(s::Mafic_Solubility)
+    return MaterialParamsInfo(; Equation = L"m_{H_2O},\ m_{CO_2} = f_{mafic}(P, T, X_{co2})")
+end
+
+@inline function compute_dissolved(s::Mafic_Solubility, P, T, X_co2)
+    b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, c1, c2, c3, c4 = s.coeffs
+    if P isa Quantity
+        @unpack_units T0, Tref, Pref = s
+    else
+        @unpack_val T0, Tref, Pref = s
+    end
+    Tc = (T - T0) / Tref            # ∝ T in °C
+    Pm = P / Pref                   # ∝ P in MPa
+    meq = @muladd b1 + b2 * Tc + b3 * X_co2 + b4 * Pm + b5 * Tc * X_co2 + b6 * Tc * Pm +
+        b7 * X_co2 * Pm + b8 * Tc^2 + b9 * X_co2^2 + b10 * Pm^2
+
+    # CO2 block: Liu (2005) rhyolite
+    Pw = Pm * (1 - X_co2)
+    Pc = Pm * X_co2
+    Tr = Tref / T
+    Cco2 = @muladd @pow Pc * (c1 + c2 * Pw) * Tr + Pc * (c3 * Pw^0.5 + c4 * Pw^1.5)
+
+    return (1.0e-2 * meq, 1.0e-6 * Cco2)
+end
+
+function show(io::IO, s::Mafic_Solubility)
+    return print(io, "Mafic H2O-CO2 solubility (CO2 block Liu 2005)")
+end
+
+# Gas-mixture properties -----------------------------------------------------
+"""
+    GasMixture(; Cp_h2o=3880J/kg/K, Cp_co2=1200J/kg/K, M_h2o=18.02e-3kg/mol, M_co2=44.01e-3kg/mol)
+
+H2O–CO2 gas-mixture properties keyed on the CO2 mole fraction of the gas
+`X_co2` (Degruyter & Huber 2014). The effective molar mass is
+```math
+    m_g = M_{H_2O}(1-X_{co2}) + M_{CO_2} X_{co2}
+```
+and the mass-weighted specific heat is
+```math
+    c_g = \\frac{M_{H_2O} c_{H_2O}(1-X_{co2}) + M_{CO_2} c_{CO_2} X_{co2}}{m_g}
+```
+with the reference convention ``c_g = 0`` at ``X_{co2}=0``. All fields are
+`GeoUnit`s, so the struct nondimensionalizes.
+"""
+@with_kw_noshow struct GasMixture{T, U1, U2} <: AbstractMaterialParam
+    Cp_h2o::GeoUnit{T, U1} = 3880.0J / kg / K   # specific heat of H2O gas
+    Cp_co2::GeoUnit{T, U1} = 1200.0J / kg / K   # specific heat of CO2 gas
+    M_h2o::GeoUnit{T, U2} = 18.02e-3kg / mol    # molar mass H2O
+    M_co2::GeoUnit{T, U2} = 44.01e-3kg / mol    # molar mass CO2
+end
+GasMixture(args...) = GasMixture(convert.(GeoUnit, args)...)
+isdimensional(s::GasMixture) = isdimensional(s.Cp_h2o)
+
+function param_info(s::GasMixture)
+    return MaterialParamsInfo(; Equation = L"c_g = (M_{H_2O} c_{H_2O}(1-X) + M_{CO_2} c_{CO_2} X)/m_g")
+end
+
+"""
+    effective_molar_mass(s::GasMixture, X_co2)
+
+Effective molar mass of the H2O–CO2 gas mixture at CO2 mole fraction `X_co2`.
+"""
+@inline function effective_molar_mass(s::GasMixture, X_co2)
+    @unpack_val M_h2o, M_co2 = s   # X_co2 is dimensionless; a nondimensionalized struct yields nondim output
+    return M_h2o * (1 - X_co2) + M_co2 * X_co2
+end
+
+"""
+    compute_gas_heatcapacity(s::GasMixture, X_co2)
+
+Mass-weighted specific heat of the H2O–CO2 gas mixture; zero at `X_co2 == 0`
+(reference convention).
+"""
+@inline function compute_gas_heatcapacity(s::GasMixture, X_co2)
+    @unpack_val Cp_h2o, Cp_co2, M_h2o, M_co2 = s
+    iszero(X_co2) && return zero(Cp_h2o * X_co2)
+    m_g = M_h2o * (1 - X_co2) + M_co2 * X_co2
+    return (M_h2o * Cp_h2o * (1 - X_co2) + M_co2 * Cp_co2 * X_co2) / m_g
+end
+
+# Shared keyword / NamedTuple entry points -----------------------------------
+@inline function compute_dissolved(s::AbstractSolubility; P = 0.0e0, T = 0.0e0, X_co2 = 0.0e0, kwargs...)
+    return compute_dissolved(s, P, T, X_co2)
+end
+@inline compute_dissolved(s::AbstractSolubility, args::NamedTuple) = compute_dissolved(s; args...)
+
+# Phase-struct dispatch
+@inline compute_dissolved(s::AbstractMaterialParamsStruct, args) = compute_dissolved(s.Solubility[1], args)
+
+# ForwardDiff partials — replace the reference's hand-coded analytic partials.
+# Each returns (∂m_h2o/∂·, ∂m_co2/∂·).
+_dissolved_svec(s::AbstractSolubility, P, T, X_co2) = SVector(compute_dissolved(s, P, T, X_co2)...)
+
+"""
+    ∂dissolved_∂P(s, P, T, X_co2) -> (∂m_h2o/∂P, ∂m_co2/∂P)
+
+ForwardDiff partial derivatives of [`compute_dissolved`](@ref) with respect to
+pressure. Companions [`∂dissolved_∂T`](@ref), [`∂dissolved_∂Xco2`](@ref).
+"""
+∂dissolved_∂P(s::AbstractSolubility, P, T, X_co2) = Tuple(ForwardDiff.derivative(p -> _dissolved_svec(s, p, T, X_co2), P))
+
+"""
+    ∂dissolved_∂T(s, P, T, X_co2) -> (∂m_h2o/∂T, ∂m_co2/∂T)
+"""
+∂dissolved_∂T(s::AbstractSolubility, P, T, X_co2) = Tuple(ForwardDiff.derivative(t -> _dissolved_svec(s, P, t, X_co2), T))
+
+"""
+    ∂dissolved_∂Xco2(s, P, T, X_co2) -> (∂m_h2o/∂X_co2, ∂m_co2/∂X_co2)
+"""
+∂dissolved_∂Xco2(s::AbstractSolubility, P, T, X_co2) = Tuple(ForwardDiff.derivative(x -> _dissolved_svec(s, P, T, x), X_co2))
+
+# In-place multiphase: fills two arrays (tuple output has no scalar phase-ratio
+# form, so this does not route through compute_param!).
+"""
+    compute_dissolved!(m_h2o, m_co2, MatParam, Phases, args)
+
+In-place dissolved H2O and CO2 for a domain: `MatParam` an `NTuple` of phase
+structs, `Phases` an integer phase array, `args` a NamedTuple of `P, T, X_co2`
+(scalars or index-matched arrays). Also accepts a single solubility or phase
+struct in place of `(MatParam, Phases)`.
+"""
+function compute_dissolved!(
+        m_h2o::AbstractArray, m_co2::AbstractArray,
+        MatParam::NTuple{N, AbstractMaterialParamsStruct}, Phases::AbstractArray, args
+    ) where {N}
+    for I in eachindex(m_h2o, m_co2, Phases)
+        argsi = _args_at(args, I)
+        mh, mc = compute_dissolved(MatParam, Phases[I], argsi)
+        m_h2o[I] = mh
+        m_co2[I] = mc
+    end
+    return nothing
+end
+
+function compute_dissolved!(
+        m_h2o::AbstractArray, m_co2::AbstractArray,
+        s::Union{AbstractSolubility, AbstractMaterialParamsStruct}, args
+    )
+    for I in eachindex(m_h2o, m_co2)
+        argsi = _args_at(args, I)
+        mh, mc = compute_dissolved(s, argsi)
+        m_h2o[I] = mh
+        m_co2[I] = mc
+    end
+    return nothing
+end
+
+# Per-index slice of a NamedTuple of scalars/arrays (mirrors compute_param!)
+@inline function _args_at(args::NamedTuple, I)
+    v = getindex.(values(args), I)   # scalar overload makes this work for scalars too
+    return (; zip(keys(args), v)...)
+end
+
+# Multiphase phase-selection (single point); routes tuple through compute_param
+@inline compute_dissolved(args::Vararg{Any, N}) where {N} = compute_param(compute_dissolved, args...)
+
+end

--- a/src/Solubility/Solubility.jl
+++ b/src/Solubility/Solubility.jl
@@ -107,7 +107,7 @@ X_co2)` and `compute_dissolved(s, args::NamedTuple)`.
     Tr = Tref / T                   # ∝ 1/T [K]
 
 Pw_sqrt  = sqrt(Pw)     # Pw^0.5
-Pw_15    = Pw * sPw     # Pw^1.5
+Pw_15    = Pw * Pw_sqrt     # Pw^1.5
 
 meq  = @muladd (b1 * Pw_sqrt + b2 * Pw + b3 * Pw_15) * Tr + b4 * Pw_15 + Pc * (b5 * Pw_sqrt + b6 * Pw)
 Cco2 = @muladd Pc * ((c1 + c2 * Pw) * Tr + c3 * Pw_sqrt + c4 * Pw_15)

--- a/src/Solubility/Solubility.jl
+++ b/src/Solubility/Solubility.jl
@@ -18,18 +18,18 @@ include("../Computations.jl")
 
 abstract type AbstractSolubility{T} <: AbstractMaterialParam end
 
-export compute_dissolved,           # (m_h2o, m_co2) mass fractions
-    compute_dissolved!,             # in-place, fills two arrays
-    compute_dissolved_ratio,        # phase-ratio mix of both outputs
-    ∂dissolved_∂P,                  # ForwardDiff partials, both outputs
+export compute_dissolved, # (m_h2o, m_co2) mass fractions
+    compute_dissolved!, # in-place, fills two arrays
+    compute_dissolved_ratio, # phase-ratio mix of both outputs
+    ∂dissolved_∂P, # ForwardDiff partials, both outputs
     ∂dissolved_∂T,
     ∂dissolved_∂Xco2,
     param_info,
     AbstractSolubility,
-    Liu2005_Solubility,             # silicic (rhyolite)
-    Mafic_Solubility,               # mafic (basalt), CO2 block still Liu rhyolite
-    GasMixture,                     # H2O-CO2 gas-mixture properties
-    compute_gas_heatcapacity,       # mass-weighted specific heat c_g(X_co2)
+    Liu2005_Solubility, # silicic (rhyolite)
+    Mafic_Solubility, # mafic (basalt), CO2 block still Liu rhyolite
+    GasMixture, # H2O-CO2 gas-mixture properties
+    compute_gas_heatcapacity, # mass-weighted specific heat c_g(X_co2)
     effective_molar_mass            # m_g(X_co2)
 
 # Empty routine when no solubility is defined
@@ -67,8 +67,10 @@ struct Liu2005_Solubility{T, U1, U2} <: AbstractSolubility{T}
     Tref::GeoUnit{T, U2}      # temperature scale of the fit (1 K)
 
     function Liu2005_Solubility(;
-            coeffs = (354.94, 9.623, -1.5223, 1.2439e-3, -1.084e-4, -1.362e-5,
-                5668.0, -55.99, 0.4133, 2.041e-3),
+            coeffs = (
+                354.94, 9.623, -1.5223, 1.2439e-3, -1.084e-4, -1.362e-5,
+                5668.0, -55.99, 0.4133, 2.041e-3,
+            ),
             Pref = 1.0e6Pa, Tref = 1.0K
         )
         PrefU = convert(GeoUnit, Pref)
@@ -135,10 +137,12 @@ struct Mafic_Solubility{T, U1, U2} <: AbstractSolubility{T}
     Pref::GeoUnit{T, U2}      # pressure scale of the fit (1 MPa)
 
     function Mafic_Solubility(;
-            coeffs = (2.99622526644026, 0.00322422830627781, -9.1389095360385,
+            coeffs = (
+                2.99622526644026, 0.00322422830627781, -9.1389095360385,
                 0.0336065247530767, 0.00747236662935722, -0.0000150329805347769,
                 -0.01233608521548, -4.14842647942619e-6, -0.655454303068124,
-                -7.35270395041104e-6, 5668.0, -55.99, 0.4133, 2.041e-3),
+                -7.35270395041104e-6, 5668.0, -55.99, 0.4133, 2.041e-3,
+            ),
             T0 = 273.15K, Tref = 1.0K, Pref = 1.0e6Pa
         )
         T0U = convert(GeoUnit, T0)

--- a/src/Solubility/Solubility.jl
+++ b/src/Solubility/Solubility.jl
@@ -106,8 +106,11 @@ X_co2)` and `compute_dissolved(s, args::NamedTuple)`.
     Pc = P * X_co2 / Pref           # ∝ CO2 partial pressure in MPa
     Tr = Tref / T                   # ∝ 1/T [K]
 
-    meq = @muladd @pow (b1 * Pw^0.5 + b2 * Pw + b3 * Pw^1.5) * Tr + b4 * Pw^1.5 + Pc * (b5 * Pw^0.5 + b6 * Pw)
-    Cco2 = @muladd @pow Pc * (c1 + c2 * Pw) * Tr + Pc * (c3 * Pw^0.5 + c4 * Pw^1.5)
+Pw_sqrt  = sqrt(Pw)     # Pw^0.5
+Pw_15    = Pw * sPw     # Pw^1.5
+
+meq  = @muladd (b1 * Pw_sqrt + b2 * Pw + b3 * Pw_15) * Tr + b4 * Pw_15 + Pc * (b5 * Pw_sqrt + b6 * Pw)
+Cco2 = @muladd Pc * ((c1 + c2 * Pw) * Tr + c3 * Pw_sqrt + c4 * Pw_15)
 
     return (1.0e-2 * meq, 1.0e-6 * Cco2)   # wt% -> fraction ; ppm -> fraction
 end
@@ -170,14 +173,18 @@ end
     end
     Tc = (T - T0) / Tref            # ∝ T in °C
     Pm = P / Pref                   # ∝ P in MPa
-    meq = @muladd b1 + b2 * Tc + b3 * X_co2 + b4 * Pm + b5 * Tc * X_co2 + b6 * Tc * Pm +
-        b7 * X_co2 * Pm + b8 * Tc^2 + b9 * X_co2^2 + b10 * Pm^2
+meq = @muladd b1 +
+    Tc * (b2 + b8 * Tc + b5 * X_co2 + b6 * Pm) +
+    X_co2 * (b3 + b9 * X_co2 + b7 * Pm) +
+    Pm * (b4 + b10 * Pm)
 
     # CO2 block: Liu (2005) rhyolite
     Pw = Pm * (1 - X_co2)
     Pc = Pm * X_co2
     Tr = Tref / T
-    Cco2 = @muladd @pow Pc * (c1 + c2 * Pw) * Tr + Pc * (c3 * Pw^0.5 + c4 * Pw^1.5)
+Pw_sqrt = sqrt(Pw)        # Pw^0.5
+Pw_15   = Pw * Pw_sqrt    # Pw^1.5
+Cco2 = @muladd Pc * ((c1 + c2 * Pw) * Tr + c3 * Pw_sqrt + c4 * Pw_15)
 
     return (1.0e-2 * meq, 1.0e-6 * Cco2)
 end
@@ -316,7 +323,8 @@ compute_dissolved_ratio(args::Vararg{Any, N}) where {N} = compute_dissolved_time
     return quote
         mh = zero($T)
         mc = zero($T)
-        Base.Cartesian.@nexprs $N i -> begin
+        Base.@nexprs $N i -> begin
+             @inline
             hᵢ, cᵢ = fn(MatParam[i], argsi)
             r = @inbounds PhaseRatios[i]
             mh += hᵢ * r

--- a/src/Solubility/Solubility.jl
+++ b/src/Solubility/Solubility.jl
@@ -4,12 +4,6 @@ module Solubility
 # Degruyter & Huber (2014)-type magma-chamber models. Each closure returns
 # *both* dissolved H2O and dissolved CO2 mass fractions at a point, because the
 # two share the partial pressures Pw = P(1-X_co2), Pc = P·X_co2.
-#
-# The empirical fits are in specific units (MPa, K/°C). Following the package
-# convention (see GiordanoMeltViscosity), the dimensionless fit coefficients are
-# stored as a plain NTuple, while the dimensional reference quantities that set
-# those units are GeoUnit fields; the closures are written in terms of the
-# dimensionless groups P/Pref, (T-T0)/Tref, Tref/T, so they nondimensionalize.
 
 using Parameters, Unitful, LaTeXStrings, MuladdMacro
 using ForwardDiff, StaticArrays
@@ -26,6 +20,7 @@ abstract type AbstractSolubility{T} <: AbstractMaterialParam end
 
 export compute_dissolved,           # (m_h2o, m_co2) mass fractions
     compute_dissolved!,             # in-place, fills two arrays
+    compute_dissolved_ratio,        # phase-ratio mix of both outputs
     ∂dissolved_∂P,                  # ForwardDiff partials, both outputs
     ∂dissolved_∂T,
     ∂dissolved_∂Xco2,
@@ -236,7 +231,7 @@ Mass-weighted specific heat of the H2O–CO2 gas mixture; zero at `X_co2 == 0`
     @unpack_val Cp_h2o, Cp_co2, M_h2o, M_co2 = s
     iszero(X_co2) && return zero(Cp_h2o * X_co2)
     m_g = M_h2o * (1 - X_co2) + M_co2 * X_co2
-    return (M_h2o * Cp_h2o * (1 - X_co2) + M_co2 * Cp_co2 * X_co2) / m_g
+    return (M_h2o * Cp_h2o * (1 - X_co2) + M_co2 * Cp_co2 * X_co2) * inv(m_g)
 end
 
 # Shared keyword / NamedTuple entry points -----------------------------------
@@ -245,8 +240,11 @@ end
 end
 @inline compute_dissolved(s::AbstractSolubility, args::NamedTuple) = compute_dissolved(s; args...)
 
-# Phase-struct dispatch
-@inline compute_dissolved(s::AbstractMaterialParamsStruct, args) = compute_dissolved(s.Solubility[1], args)
+# Phase-struct dispatch; a phase with no solubility model contributes nothing.
+@inline function compute_dissolved(s::AbstractMaterialParamsStruct, args)
+    isempty(s.Solubility) && return (0.0e0, 0.0e0)
+    return compute_dissolved(s.Solubility[1], args)
+end
 
 # ForwardDiff partials — replace the reference's hand-coded analytic partials.
 # Each returns (∂m_h2o/∂·, ∂m_co2/∂·).
@@ -270,25 +268,21 @@ pressure. Companions [`∂dissolved_∂T`](@ref), [`∂dissolved_∂Xco2`](@ref)
 """
 ∂dissolved_∂Xco2(s::AbstractSolubility, P, T, X_co2) = Tuple(ForwardDiff.derivative(x -> _dissolved_svec(s, P, T, x), X_co2))
 
-# In-place multiphase: fills two arrays (tuple output has no scalar phase-ratio
-# form, so this does not route through compute_param!).
+# Two output arrays, so this cannot route through the single-array `compute_param!`.
 """
     compute_dissolved!(m_h2o, m_co2, MatParam, Phases, args)
 
-In-place dissolved H2O and CO2 for a domain: `MatParam` an `NTuple` of phase
-structs, `Phases` an integer phase array, `args` a NamedTuple of `P, T, X_co2`
-(scalars or index-matched arrays). Also accepts a single solubility or phase
-struct in place of `(MatParam, Phases)`.
+In-place dissolved H2O and CO2 over a domain. `args` is a NamedTuple of `P, T,
+X_co2` index-matched to the output arrays. Also accepts a single solubility or
+phase struct in place of `(MatParam, Phases)`.
 """
 function compute_dissolved!(
         m_h2o::AbstractArray, m_co2::AbstractArray,
         MatParam::NTuple{N, AbstractMaterialParamsStruct}, Phases::AbstractArray, args
     ) where {N}
     for I in eachindex(m_h2o, m_co2, Phases)
-        argsi = _args_at(args, I)
-        mh, mc = compute_dissolved(MatParam, Phases[I], argsi)
-        m_h2o[I] = mh
-        m_co2[I] = mc
+        argsi = (; zip(keys(args), getindex.(values(args), I))...)
+        m_h2o[I], m_co2[I] = compute_dissolved(MatParam, Phases[I], argsi)
     end
     return nothing
 end
@@ -298,21 +292,34 @@ function compute_dissolved!(
         s::Union{AbstractSolubility, AbstractMaterialParamsStruct}, args
     )
     for I in eachindex(m_h2o, m_co2)
-        argsi = _args_at(args, I)
-        mh, mc = compute_dissolved(s, argsi)
-        m_h2o[I] = mh
-        m_co2[I] = mc
+        argsi = (; zip(keys(args), getindex.(values(args), I))...)
+        m_h2o[I], m_co2[I] = compute_dissolved(s, argsi)
     end
     return nothing
 end
 
-# Per-index slice of a NamedTuple of scalars/arrays (mirrors compute_param!)
-@inline function _args_at(args::NamedTuple, I)
-    v = getindex.(values(args), I)   # scalar overload makes this work for scalars too
-    return (; zip(keys(args), v)...)
-end
+# Integer-phase selection / single struct over a domain (mirrors compute_meltfraction).
+compute_dissolved(args::Vararg{Any, N}) where {N} = compute_param(compute_dissolved, args...)
 
-# Multiphase phase-selection (single point); routes tuple through compute_param
-@inline compute_dissolved(args::Vararg{Any, N}) where {N} = compute_param(compute_dissolved, args...)
+# Phase-ratio mix of both outputs (mirrors compute_meltfraction_ratio). The
+# shared compute_param_times_frac sums a scalar, so the two-element output gets
+# its own unrolled dot-product, evaluating each phase once.
+compute_dissolved_ratio(args::Vararg{Any, N}) where {N} = compute_dissolved_times_frac(compute_dissolved, args...)
+
+@generated function compute_dissolved_times_frac(
+        fn::F, PhaseRatios::Union{NTuple{N, T}, SVector{N, T}}, MatParam::NTuple{N, AbstractMaterialParamsStruct}, argsi
+    ) where {F <: Function, N, T}
+    return quote
+        mh = zero($T)
+        mc = zero($T)
+        Base.Cartesian.@nexprs $N i -> begin
+            hᵢ, cᵢ = fn(MatParam[i], argsi)
+            r = @inbounds PhaseRatios[i]
+            mh += hᵢ * r
+            mc += cᵢ * r
+        end
+        return (mh, mc)
+    end
+end
 
 end

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -94,5 +94,5 @@ function create_module(caller::Module, modulename::Symbol, kwargs_expr::Expr...)
 end
 
 function use_module(caller::Module, modulename::Symbol)
-    return @eval(caller, using $(Symbol(caller)).$modulename)
+    return @eval(caller, using .$modulename)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,22 @@
-using Test, Statistics
+using GeoParams
+using Test, Statistics, ParallelTestRunner
+using LaTeXStrings
 
 
-function runtests()
-    files = readdir(@__DIR__)
-    test_files = filter(startswith("test_"), files)
+function runtests(args)
+    printstyled("Testing package GeoParams.jl\n"; bold = true, color = :white)
 
-    for f in test_files
-        if !isdir(f)
-            include(f)
-        end
+    testsuite = find_tests(@__DIR__)
+    pt_args = ParallelTestRunner.parse_args(args)
+    nfail = 0
+
+    try
+        ParallelTestRunner.runtests(GeoParams, pt_args; testsuite)
+    catch ex
+        nfail += 1
     end
-    return
+
+    return nfail
 end
 
-runtests()
+exit(runtests(ARGS))

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -1,6 +1,12 @@
 using Test, GeoParams, StaticArrays, LaTeXStrings
 import ForwardDiff.derivative
+
 @testset "Density.jl" begin
+
+    #Set alias for density function
+    if !isdefined(Main, :GeoParamsAliases)
+        eval(:(@use GeoParamsAliases density = ρ))
+    end
 
     #Make sure that structs are isbits
     x = ConstantDensity()
@@ -278,9 +284,10 @@ import ForwardDiff.derivative
     num_alloc = @allocated compute_density!(rho, Mat_tup1, Phases, args)   #      287.416 μs (0 allocations: 0 bytes)
     @test sum(rho) / 400^2 ≈ 2575.250013499998
     # @test num_alloc ≤ 32
-
+    #Same test using function alias
     rho = zeros(size(Phases))
     compute_density!(rho, Mat_tup1, Phases, args)
+    ρ!(rho, Mat_tup1, Phases, args)
     num_alloc = @allocated compute_density!(rho, Mat_tup1, Phases, args)
     @test sum(rho) / 400^2 ≈ 2575.250013499998
     # @test num_alloc ≤ 32

--- a/test/test_Density.jl
+++ b/test/test_Density.jl
@@ -2,11 +2,6 @@ using Test, GeoParams, StaticArrays, LaTeXStrings
 import ForwardDiff.derivative
 @testset "Density.jl" begin
 
-    #Set alias for density function
-    if !isdefined(Main, :GeoParamsAliases)
-        eval(:(@use GeoParamsAliases density = ρ))
-    end
-
     #Make sure that structs are isbits
     x = ConstantDensity()
     @test isbits(x)
@@ -138,7 +133,7 @@ import ForwardDiff.derivative
     @test derivative(x -> compute_density(Compressible_Density(), (P = x, T = args.T)), args.P) ≈ 2.90000290000145e-6 rtol = 1.0e-6
 
     # Read Phase diagram interpolation object
-    fname = "test_data/Peridotite_dry.in"
+    fname = joinpath(@__DIR__, "test_data", "Peridotite_dry.in")
     PD_data = PerpleX_LaMEM_Diagram(fname)
     @test PD_data.meltFrac(1500, 1.0e7) ≈ 0.2538048323727155
     @test PD_data.Rho(1500, 1.0e7) ≈ 3054.8671154189938
@@ -150,7 +145,7 @@ import ForwardDiff.derivative
     @test compute_density(PD_data; P = 1.0e7, T = 1500.0) ≈ 3054.8671154189938 # optional parameter syntax
 
 
-    Rhyolite = "test_data/MAGEMin_Rhyolite.in"
+    Rhyolite = joinpath(@__DIR__, "test_data", "MAGEMin_Rhyolite.in")
 
     PD_MAGEMin = MAGEMin_Diagram(Rhyolite)
     @test PD_MAGEMin.Rho(800.0, 1.0e7) ≈ 2701.3786579954285
@@ -205,7 +200,7 @@ import ForwardDiff.derivative
         Name = "Mantle",
         Phase = 0,
         CreepLaws = (PowerlawViscous(), LinearViscous(; η = 1.0e23Pa * s)),
-        Density = PerpleX_LaMEM_Diagram("test_data/sediments_1.in"),
+        Density = PerpleX_LaMEM_Diagram(joinpath(@__DIR__, "test_data", "sediments_1.in")),
     )
 
     MatParam[2] = SetMaterialParams(;
@@ -284,9 +279,8 @@ import ForwardDiff.derivative
     @test sum(rho) / 400^2 ≈ 2575.250013499998
     # @test num_alloc ≤ 32
 
-    #Same test using function alias
     rho = zeros(size(Phases))
-    ρ!(rho, Mat_tup1, Phases, args)
+    compute_density!(rho, Mat_tup1, Phases, args)
     num_alloc = @allocated compute_density!(rho, Mat_tup1, Phases, args)
     @test sum(rho) / 400^2 ≈ 2575.250013499998
     # @test num_alloc ≤ 32

--- a/test/test_DiffusionCreep.jl
+++ b/test/test_DiffusionCreep.jl
@@ -1,5 +1,6 @@
 using Test
 using GeoParams
+using LaTeXStrings
 import GeoParams.Diffusion
 
 @testset "DiffusionCreepLaws" begin

--- a/test/test_DislocationCreep.jl
+++ b/test/test_DislocationCreep.jl
@@ -1,5 +1,6 @@
 using Test
 using GeoParams
+using LaTeXStrings
 import GeoParams.Dislocation
 
 @testset "DislocationCreepLaws" begin

--- a/test/test_Elasticity.jl
+++ b/test/test_Elasticity.jl
@@ -1,6 +1,9 @@
 using Test
 using GeoParams
+using LaTeXStrings
 import GeoParams: effective_ε
+import GeoParams.Diffusion
+import GeoParams.Dislocation
 
 @testset "Elasticity.jl" begin
 

--- a/test/test_Energy.jl
+++ b/test/test_Energy.jl
@@ -286,7 +286,7 @@ import ForwardDiff as FD
     @test compute_heatcapacity(x_D, args) ≈ dimensionalize(Cp_nd, J / kg / K, CharUnits_GEO).val
 
     Cp_PD = zeros(11, 11)
-    Rhyolite = "test_data/MAGEMin_Rhyolite.in"
+    Rhyolite = joinpath(@__DIR__, "test_data", "MAGEMin_Rhyolite.in")
     PD_MAGEMin = MAGEMin_Diagram(Rhyolite)
     args = (; T = 1200.0 + 273, P = 1.0e7, index = 10)
     compute_heatcapacity!(Cp_PD, PD_MAGEMin, args)

--- a/test/test_GasDensity.jl
+++ b/test/test_GasDensity.jl
@@ -1,0 +1,100 @@
+using Test, GeoParams, StaticArrays, LaTeXStrings
+using ForwardDiff: derivative
+
+@testset "GasDensity.jl" begin
+
+    # Redlich-Kwong gas density -------------------------------------------
+    rk = RedlichKwong_Density()
+    @test isbits(rk)
+    @test isdimensional(rk) === true
+    @test param_info(rk).Equation isa LaTeXString
+    @test sprint(show, rk) isa String
+    @test occursin("Redlich-Kwong", sprint(show, rk))
+
+    # reference value: ~360 kg/m³ at 200 MPa, 1200 K
+    @test rk(; P = 2.0e8, T = 1200.0) ≈ 3.6e2 rtol = 0.1
+    @test compute_density(rk, (; P = 2.0e8, T = 1200.0)) ≈ rk(; P = 2.0e8, T = 1200.0)
+    @test rk((; P = 2.0e8, T = 1200.0)) ≈ rk(; P = 2.0e8, T = 1200.0)
+
+    # monotonicity (plan acceptance)
+    @test rk(; P = 1.0e8, T = 1123.15) > rk(; P = 1.0e8, T = 1173.15)   # hotter -> lighter
+    @test rk(; P = 3.0e8, T = 1123.15) > rk(; P = 1.0e8, T = 1123.15)   # higher P -> denser
+
+    # dimensional Quantity input hits the @unpack_units branch
+    @test ustrip(kg / m^3, rk(; P = 200.0MPa, T = 1200.0K)) ≈ rk(; P = 2.0e8, T = 1200.0) rtol = 1.0e-6
+
+    # custom coefficients through the keyword constructor
+    rk2 = RedlichKwong_Density(; coeffs = (-100.0, 120.0, 110.0))
+    @test rk2.coeffs == (-100.0, 120.0, 110.0)
+
+    # nondimensionalization round-trip: dimensionalized result matches
+    CharDim = GEO_units(; viscosity = 1.0e19, length = 1000km)
+    rk_nd = nondimensionalize(rk, CharDim)
+    @test isdimensional(rk_nd) === false
+    ρ_nd = rk_nd(;
+        P = nondimensionalize(2.0e8Pa, CharDim),
+        T = nondimensionalize(1200.0K, CharDim),
+    )
+    @test ustrip(dimensionalize(ρ_nd, kg / m^3, CharDim)) ≈ rk(; P = 2.0e8, T = 1200.0)
+
+    # Ideal-gas density ----------------------------------------------------
+    ig = IdealGas_Density()
+    @test isbits(ig)
+    @test isdimensional(ig) === true
+    @test param_info(ig).Equation === L"\rho_g = P/(R_s T)"
+    @test sprint(show, ig) isa String
+
+    # ρ = P/(Rs T)
+    @test ig(; P = 1.0e8, T = 1000.0) ≈ 1.0e8 / (461.5 * 1000.0)
+    @test compute_density(ig, (; P = 1.0e8, T = 1000.0)) ≈ 1.0e8 / (461.5 * 1000.0)
+    @test ig((; P = 1.0e8, T = 1000.0)) ≈ 1.0e8 / (461.5 * 1000.0)
+
+    # exact analytic derivative ∂ρ/∂P = 1/(Rs T)
+    @test derivative(P -> ig(; P, T = 1000.0), 1.0e8) ≈ 1.0 / (461.5 * 1000.0)
+
+    # Quantity branch
+    @test ustrip(kg / m^3, ig(; P = 100.0MPa, T = 1000.0K)) ≈ ig(; P = 1.0e8, T = 1000.0) rtol = 1.0e-6
+
+    # nondim round-trip (homogeneous -> exact)
+    ig_nd = nondimensionalize(ig, CharDim)
+    @test isdimensional(ig_nd) === false
+    ρig_nd = ig_nd(;
+        P = nondimensionalize(1.0e8Pa, CharDim),
+        T = nondimensionalize(1000.0K, CharDim),
+    )
+    @test ustrip(dimensionalize(ρig_nd, kg / m^3, CharDim)) ≈ ig(; P = 1.0e8, T = 1000.0)
+
+    # Three-phase density --------------------------------------------------
+    tp = ThreePhase_Density(;
+        ρmelt = ConstantDensity(ρ = 2300kg / m^3),
+        ρx = ConstantDensity(ρ = 2600kg / m^3),
+        ρgas = ConstantDensity(ρ = 1kg / m^3),
+    )
+    @test isbits(tp)
+    @test isdimensional(tp) === true
+    @test param_info(tp).Equation isa LaTeXString
+    @test occursin("Three-phase", sprint(show, tp))
+
+    # volume-fraction mixture: 40% crystals, no gas
+    @test tp(; ϕ_gas = 0.0, ϕ_x = 0.4) ≈ 0.6 * 2300 + 0.4 * 2600
+    @test compute_density(tp, (; ϕ_gas = 0.0, ϕ_x = 0.4)) ≈ 0.6 * 2300 + 0.4 * 2600
+    @test tp((; ϕ_gas = 0.0, ϕ_x = 0.4)) ≈ 0.6 * 2300 + 0.4 * 2600
+
+    # adding gas lowers the density
+    @test tp(; ϕ_gas = 0.1, ϕ_x = 0.4) < tp(; ϕ_gas = 0.0, ϕ_x = 0.4)
+
+    # default gas is Redlich-Kwong: mixture responds to P, T through the EOS
+    tp_rk = ThreePhase_Density()
+    ρmix = tp_rk(; ϕ_gas = 0.2, ϕ_x = 0.3, P = 2.0e8, T = 1200.0)
+    @test 0 < ρmix < 2600
+
+    # nondim round-trip on the three-phase mixture (constant sub-densities)
+    tp_nd = nondimensionalize(tp, CharDim)
+    @test isdimensional(tp_nd) === false
+    ρtp_nd = tp_nd(; ϕ_gas = 0.0, ϕ_x = 0.4)
+    @test ustrip(dimensionalize(ρtp_nd, kg / m^3, CharDim)) ≈ tp(; ϕ_gas = 0.0, ϕ_x = 0.4)
+
+    # SetMaterialParams accepts the new densities in the Density slot
+    ph = SetMaterialParams(; Phase = 1, Density = RedlichKwong_Density())
+    @test compute_density(ph, (; P = 2.0e8, T = 1200.0)) ≈ rk(; P = 2.0e8, T = 1200.0)
+end

--- a/test/test_GrainBoundarySliding.jl
+++ b/test/test_GrainBoundarySliding.jl
@@ -1,5 +1,6 @@
 using Test
 using GeoParams
+using LaTeXStrings
 import GeoParams.GBS
 
 @testset "GrainBoundarySliding" begin

--- a/test/test_Gravity.jl
+++ b/test/test_Gravity.jl
@@ -1,4 +1,5 @@
 using Test, GeoParams
+using LaTeXStrings
 
 @testset "Gravity" begin
 

--- a/test/test_MaterialParameters.jl
+++ b/test/test_MaterialParameters.jl
@@ -65,7 +65,7 @@ using GeoParams
         Name = "Mantle",
         Phase = Phase,
         CreepLaws = (PowerlawViscous(), LinearViscous(; η = 1.0e23Pa * s)),
-        Density = PerpleX_LaMEM_Diagram("test_data/Peridotite_dry.in"),
+        Density = PerpleX_LaMEM_Diagram(joinpath(@__DIR__, "test_data", "Peridotite_dry.in")),
         CharDim = GEO_units(),
     )
 

--- a/test/test_MeltingParam.jl
+++ b/test/test_MeltingParam.jl
@@ -2,6 +2,7 @@ using Test
 using LinearAlgebra
 using GeoParams
 using StaticArrays
+using LaTeXStrings
 
 @testset "MeltingParam.jl" begin
 
@@ -208,7 +209,7 @@ using StaticArrays
     =#
 
 
-    Rhyolite = "test_data/MAGEMin_Rhyolite.in"
+    Rhyolite = joinpath(@__DIR__, "test_data", "MAGEMin_Rhyolite.in")
     PD_MAGEMin = MAGEMin_Diagram(Rhyolite)
     @test sprint(show, PD_MAGEMin) isa String
     args = (; T = ustrip.(Tdata), P = fill(1.0e7, length(Tdata)))
@@ -219,7 +220,7 @@ using StaticArrays
     # Test computation of melt parameterization for the whole computational domain, using arrays
     MatParam = Vector{MaterialParams}(undef, 5)
     MatParam[1] = SetMaterialParams(;
-        Name = "Mantle", Phase = 1, Melting = PerpleX_LaMEM_Diagram("test_data/Peridotite_dry.in")
+        Name = "Mantle", Phase = 1, Melting = PerpleX_LaMEM_Diagram(joinpath(@__DIR__, "test_data", "Peridotite_dry.in"))
     )
 
     MatParam[2] = SetMaterialParams(;

--- a/test/test_MeltingParam.jl
+++ b/test/test_MeltingParam.jl
@@ -380,4 +380,57 @@ using StaticArrays
         @test compute_dϕdT(vm; index = 3) == 0.0
     end
 
+    @testset "MeltingParam_Volatile" begin
+        p = MeltingParam_Volatile()
+        @test isbits(p)
+        @test param_info(p).Equation isa LaTeXString
+        @test occursin("Volatile-dependent", sprint(show, p))
+
+        # melt fraction stays a fraction
+        ϕ_dry = p(; T = 1100.0, P = 2.0e8, mH2O = 0.0, mCO2 = 0.0)
+        @test 0.0 <= ϕ_dry <= 1.0
+
+        # dissolved water depresses the liquidus -> more melt at fixed T
+        ϕ_wet = p(; T = 1100.0, P = 2.0e8, mH2O = 0.04, mCO2 = 0.0)
+        @test ϕ_wet > ϕ_dry
+
+        # hotter -> more melt (erfc monotone)
+        @test p(; T = 1200.0, P = 2.0e8, mH2O = 0.04) > ϕ_wet
+
+        # compute_meltfraction / callable-with-args forms agree
+        args = (; T = 1100.0, P = 2.0e8, mH2O = 0.04, mCO2 = 0.0)
+        @test compute_meltfraction(p, args) == ϕ_wet
+        @test p(args) == ϕ_wet
+
+        # dϕ/dT by ForwardDiff vs central finite difference
+        d = compute_dϕdT(p; T = 1100.0, P = 2.0e8, mH2O = 0.04, mCO2 = 0.0)
+        h = 1.0e-2
+        fd = (p(; T = 1100.0 + h, P = 2.0e8, mH2O = 0.04) - p(; T = 1100.0 - h, P = 2.0e8, mH2O = 0.04)) / (2h)
+        @test d ≈ fd rtol = 1.0e-4
+        # more melt as it heats up -> dϕ/dT > 0
+        @test d > 0
+
+        # in-place dϕ/dT
+        Tarr = [1050.0, 1100.0, 1150.0]
+        darr = zeros(3)
+        compute_dϕdT!(darr, p; T = Tarr)
+        @test darr[2] ≈ compute_dϕdT(p; T = 1100.0)
+
+        # dimensional Quantity input (the @unpack_units branch)
+        @test p(; T = 1100.0K, P = 200.0MPa, mH2O = 0.04) ≈ ϕ_wet rtol = 1.0e-6
+
+        # nondimensionalization: ϕ is a fraction -> invariant
+        CharDim = GEO_units(; viscosity = 1.0e19, length = 1000km)
+        p_nd = nondimensionalize(p, CharDim)
+        @test p_nd(;
+            T = nondimensionalize(1100.0K, CharDim),
+            P = nondimensionalize(2.0e8Pa, CharDim),
+            mH2O = 0.04, mCO2 = 0.0,
+        ) ≈ ϕ_wet
+
+        # through SetMaterialParams
+        ph = SetMaterialParams(; Phase = 1, Melting = MeltingParam_Volatile())
+        @test compute_meltfraction(ph, args) ≈ ϕ_wet
+    end
+
 end

--- a/test/test_MeltingParam.jl
+++ b/test/test_MeltingParam.jl
@@ -416,6 +416,12 @@ using StaticArrays
         compute_dϕdT!(darr, p; T = Tarr)
         @test darr[2] ≈ compute_dϕdT(p; T = 1100.0)
 
+        # in-place dϕ/dT must honor the volatile args, not silently drop them
+        darr_wet = zeros(3)
+        compute_dϕdT!(darr_wet, p; T = Tarr, P = 2.0e8, mH2O = 0.04, mCO2 = 0.0)
+        @test darr_wet[2] ≈ compute_dϕdT(p; T = 1100.0, P = 2.0e8, mH2O = 0.04, mCO2 = 0.0)
+        @test darr_wet[2] != darr[2]   # water changes the derivative
+
         # dimensional Quantity input (the @unpack_units branch)
         @test p(; T = 1100.0K, P = 200.0MPa, mH2O = 0.04) ≈ ϕ_wet rtol = 1.0e-6
 

--- a/test/test_PeierlsCreep.jl
+++ b/test/test_PeierlsCreep.jl
@@ -1,5 +1,6 @@
 using Test
 using GeoParams
+using LaTeXStrings
 import GeoParams.Peierls
 
 @testset "PeierlsCreep" begin

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -1,6 +1,7 @@
 using Test
 using GeoParams
 using StaticArrays
+using LaTeXStrings
 
 @testset "Plasticity.jl" begin
 

--- a/test/test_SeismicVelocity.jl
+++ b/test/test_SeismicVelocity.jl
@@ -31,7 +31,7 @@ using GeoParams
     MatParam[2] = SetMaterialParams(;
         Name = "Crust",
         Phase = 2,
-        SeismicVelocity = PerpleX_LaMEM_Diagram("test_data/Peridotite_dry.in"),
+        SeismicVelocity = PerpleX_LaMEM_Diagram(joinpath(@__DIR__, "test_data", "Peridotite_dry.in")),
     )
 
     Mat_tup = Tuple(MatParam)
@@ -149,7 +149,7 @@ using GeoParams
     @test compute_wave_velocity(mat_noVs, (1.0, 2.0)) == 0.0
 
     # correct_wavevelocities_phasediagrams: full pipeline on a real lookup table
-    PD = PerpleX_LaMEM_Diagram("test_data/Peridotite_dry.in")
+    PD = PerpleX_LaMEM_Diagram(joinpath(@__DIR__, "test_data", "Peridotite_dry.in"))
 
     # default options (anelasticity + Takei melt + guarded porosity)
     PD_def = correct_wavevelocities_phasediagrams(PD)

--- a/test/test_Solubility.jl
+++ b/test/test_Solubility.jl
@@ -102,6 +102,29 @@ const No_MaterialParam = GeoParams.MaterialParameters.No_MaterialParam
     # phase-struct scalar dispatch
     @test compute_dissolved(phases[1], (; P = 2.0e8, T = 1200.0, X_co2 = 0.0))[1] ≈ mh
 
+    # integer-phase selection returns the selected phase's tuple
+    argp = (; P = 2.0e8, T = 1200.0, X_co2 = 0.3)
+    @test compute_dissolved(phases, 2, argp) == compute_dissolved(phases[2], argp)
+
+    # phase-ratio mixing: bulk mass-fraction average, both outputs mixed
+    ratios = SA[0.25, 0.75]
+    mixed = compute_dissolved_ratio(ratios, phases, argp)
+    ref_h = 0.25 * compute_dissolved(phases[1], argp)[1] + 0.75 * compute_dissolved(phases[2], argp)[1]
+    ref_c = 0.25 * compute_dissolved(phases[1], argp)[2] + 0.75 * compute_dissolved(phases[2], argp)[2]
+    @test mixed[1] ≈ ref_h
+    @test mixed[2] ≈ ref_c
+    @test compute_dissolved_ratio(Tuple(ratios), phases, argp) == mixed   # NTuple ratios too
+    # ratios sum to 1 with equal phases -> the phase value itself
+    @test all(compute_dissolved_ratio(SA[1.0, 0.0], phases, argp) .≈ compute_dissolved(phases[1], argp))
+
+    # a phase with no solubility model contributes nothing (no BoundsError)
+    phases0 = (phases[1], SetMaterialParams(; Phase = 2))
+    @test compute_dissolved(phases0, 2, argp) === (0.0, 0.0)
+    @test compute_dissolved_ratio(SA[0.5, 0.5], phases0, argp)[1] ≈ 0.5 * compute_dissolved(phases[1], argp)[1]
+
+    @test @inferred(compute_dissolved(s, 2.0e8, 1200.0, 0.3)) isa Tuple{Float64, Float64}
+    @test @inferred(compute_dissolved_ratio(ratios, phases, argp)) isa Tuple{Float64, Float64}
+
     # Gas-mixture properties ----------------------------------------------
     g = GasMixture()
     @test isbits(g)

--- a/test/test_Solubility.jl
+++ b/test/test_Solubility.jl
@@ -1,0 +1,126 @@
+using Test, GeoParams, StaticArrays, LaTeXStrings
+using ForwardDiff: derivative
+const No_MaterialParam = GeoParams.MaterialParameters.No_MaterialParam
+
+@testset "Solubility.jl" begin
+
+    # Liu et al. (2005) silicic -------------------------------------------
+    s = Liu2005_Solubility()
+    @test isbits(s)
+    @test isdimensional(s) === true
+    @test param_info(s).Equation isa LaTeXString
+    @test occursin("Liu", sprint(show, s))
+
+    # reference value: ~5.7 wt% H2O, no CO2 at X_co2 = 0 (200 MPa, 1200 K)
+    mh, mc = compute_dissolved(s, 2.0e8, 1200.0, 0.0)
+    @test 0.03 < mh < 0.07
+    @test mc == 0.0
+    # CO2 dissolves when present in the gas
+    @test compute_dissolved(s, 2.0e8, 1200.0, 0.3)[2] > 0.0
+    # more soluble at higher pressure
+    @test compute_dissolved(s, 4.0e8, 1200.0, 0.0)[1] > mh
+
+    # keyword and NamedTuple call forms
+    @test compute_dissolved(s; P = 2.0e8, T = 1200.0, X_co2 = 0.0) == (mh, mc)
+    @test compute_dissolved(s, (; P = 2.0e8, T = 1200.0, X_co2 = 0.0)) == (mh, mc)
+
+    # dimensional Quantity input (the @unpack_units branch)
+    mhq, mcq = compute_dissolved(s, 200.0MPa, 1200.0K, 0.0)
+    @test ustrip(mhq) ≈ mh rtol = 1.0e-6
+
+    # nondimensionalization: mass fractions are dimensionless -> invariant
+    CharDim = GEO_units(; viscosity = 1.0e19, length = 1000km)
+    s_nd = nondimensionalize(s, CharDim)
+    @test isdimensional(s_nd) === false
+    mh_nd, mc_nd = compute_dissolved(s_nd,
+        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0)
+    @test mh_nd ≈ mh
+    @test mc_nd == 0.0
+
+    # ForwardDiff partials vs central finite differences
+    P0, T0, X0 = 2.0e8, 1200.0, 0.3
+    dP = ∂dissolved_∂P(s, P0, T0, X0)
+    dT = ∂dissolved_∂T(s, P0, T0, X0)
+    dX = ∂dissolved_∂Xco2(s, P0, T0, X0)
+    @test length(dP) == 2 && length(dT) == 2 && length(dX) == 2
+    fd(f, x, h) = (f(x + h) .- f(x - h)) ./ (2h)
+    fdP = fd(p -> SVector(compute_dissolved(s, p, T0, X0)...), P0, 1.0e2)
+    fdT = fd(t -> SVector(compute_dissolved(s, P0, t, X0)...), T0, 1.0e-3)
+    fdX = fd(x -> SVector(compute_dissolved(s, P0, T0, x)...), X0, 1.0e-6)
+    @test all(isapprox.(dP, Tuple(fdP); rtol = 1.0e-4))
+    @test all(isapprox.(dT, Tuple(fdT); rtol = 1.0e-4))
+    @test all(isapprox.(dX, Tuple(fdX); rtol = 1.0e-4))
+
+    # degenerate X_co2 = 0: CO2 output and its pressure sensitivity vanish
+    @test ∂dissolved_∂P(s, P0, T0, 0.0)[2] == 0.0
+
+    # Mafic ----------------------------------------------------------------
+    m = Mafic_Solubility()
+    @test isbits(m)
+    @test isdimensional(m) === true
+    @test param_info(m).Equation isa LaTeXString
+    @test occursin("Mafic", sprint(show, m))
+
+    mmh, mmc = compute_dissolved(m, 2.0e8, 1200.0, 0.0)
+    @test mmh > 0.0
+    @test mmc == 0.0
+    @test compute_dissolved(m, 2.0e8, 1200.0, 0.3)[2] > 0.0
+    # Quantity branch
+    @test ustrip(compute_dissolved(m, 200.0MPa, 1200.0K, 0.0)[1]) ≈ mmh rtol = 1.0e-6
+    # nondim invariance
+    m_nd = nondimensionalize(m, CharDim)
+    @test isdimensional(m_nd) === false
+    @test compute_dissolved(m_nd,
+        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0)[1] ≈ mmh
+    # derivatives exist and are finite
+    @test all(isfinite, ∂dissolved_∂T(m, P0, T0, X0))
+
+    # empty-parameter fallback
+    @test compute_dissolved(No_MaterialParam()) === (0.0, 0.0)
+
+    # Multiphase: NTuple of phases + a phase array ------------------------
+    phases = (
+        SetMaterialParams(; Phase = 1, Solubility = Liu2005_Solubility()),
+        SetMaterialParams(; Phase = 2, Solubility = Mafic_Solubility()),
+    )
+    Phasearr = [1, 2, 1]
+    n = length(Phasearr)
+    m_h2o = zeros(n)
+    m_co2 = zeros(n)
+    args = (; P = fill(2.0e8, n), T = fill(1200.0, n), X_co2 = fill(0.3, n))
+    compute_dissolved!(m_h2o, m_co2, phases, Phasearr, args)
+    @test m_h2o[1] ≈ compute_dissolved(Liu2005_Solubility(), 2.0e8, 1200.0, 0.3)[1]
+    @test m_h2o[2] ≈ compute_dissolved(Mafic_Solubility(), 2.0e8, 1200.0, 0.3)[1]
+    @test all(m_co2 .> 0)
+
+    # single-struct in-place, and generic (view-wrapped) output arrays
+    mh_v = view(zeros(n + 2), 2:(n + 1))
+    mc_v = view(zeros(n + 2), 2:(n + 1))
+    compute_dissolved!(mh_v, mc_v, Liu2005_Solubility(), args)
+    @test all(mh_v .≈ compute_dissolved(Liu2005_Solubility(), 2.0e8, 1200.0, 0.3)[1])
+
+    # phase-struct scalar dispatch
+    @test compute_dissolved(phases[1], (; P = 2.0e8, T = 1200.0, X_co2 = 0.0))[1] ≈ mh
+
+    # Gas-mixture properties ----------------------------------------------
+    g = GasMixture()
+    @test isbits(g)
+    @test isdimensional(g) === true
+    @test param_info(g).Equation isa LaTeXString
+
+    @test effective_molar_mass(g, 0.0) ≈ 18.02e-3
+    @test effective_molar_mass(g, 1.0) ≈ 44.01e-3
+    @test effective_molar_mass(g, 0.5) ≈ (18.02e-3 + 44.01e-3) / 2
+    # c_g = 0 at X_co2 = 0 (reference convention)
+    @test compute_gas_heatcapacity(g, 0.0) == 0.0
+    # mixed value matches the formula
+    let X = 0.3
+        m_g = 18.02e-3 * (1 - X) + 44.01e-3 * X
+        cg = (18.02e-3 * 3880 * (1 - X) + 44.01e-3 * 1200 * X) / m_g
+        @test compute_gas_heatcapacity(g, X) ≈ cg
+    end
+    # nondimensionalization keeps the struct consistent
+    g_nd = nondimensionalize(g, CharDim)
+    @test isdimensional(g_nd) === false
+    @test compute_gas_heatcapacity(g_nd, 0.0) == 0.0
+end

--- a/test/test_Solubility.jl
+++ b/test/test_Solubility.jl
@@ -108,7 +108,7 @@ const No_MaterialParam = GeoParams.MaterialParameters.No_MaterialParam
 
     # integer-phase selection returns the selected phase's tuple
     argp = (; P = 2.0e8, T = 1200.0, X_co2 = 0.3)
-    @test compute_dissolved(phases, 2, argp) == compute_dissolved(phases[2], argp)
+    @test all(isapprox.((compute_dissolved(phases, 2, argp)),  compute_dissolved(phases[2], argp); rtol = 1e-10))
 
     # phase-ratio mixing: bulk mass-fraction average, both outputs mixed
     ratios = SA[0.25, 0.75]

--- a/test/test_Solubility.jl
+++ b/test/test_Solubility.jl
@@ -32,8 +32,10 @@ const No_MaterialParam = GeoParams.MaterialParameters.No_MaterialParam
     CharDim = GEO_units(; viscosity = 1.0e19, length = 1000km)
     s_nd = nondimensionalize(s, CharDim)
     @test isdimensional(s_nd) === false
-    mh_nd, mc_nd = compute_dissolved(s_nd,
-        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0)
+    mh_nd, mc_nd = compute_dissolved(
+        s_nd,
+        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0
+    )
     @test mh_nd ≈ mh
     @test mc_nd == 0.0
 
@@ -70,8 +72,10 @@ const No_MaterialParam = GeoParams.MaterialParameters.No_MaterialParam
     # nondim invariance
     m_nd = nondimensionalize(m, CharDim)
     @test isdimensional(m_nd) === false
-    @test compute_dissolved(m_nd,
-        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0)[1] ≈ mmh
+    @test compute_dissolved(
+        m_nd,
+        nondimensionalize(2.0e8Pa, CharDim), nondimensionalize(1200.0K, CharDim), 0.0
+    )[1] ≈ mmh
     # derivatives exist and are finite
     @test all(isfinite, ∂dissolved_∂T(m, P0, T0, X0))
 

--- a/test/test_Traits.jl
+++ b/test/test_Traits.jl
@@ -126,7 +126,7 @@ end
 @testset "Density traits" begin
     v1 = ConstantDensity()
     v2 = PT_Density()
-    v3 = MAGEMin_Diagram("test_data/MAGEMin_Rhyolite.in")
+    v3 = MAGEMin_Diagram(joinpath(@__DIR__, "test_data", "MAGEMin_Rhyolite.in"))
     d1 = SetMaterialParams(; Density = v1)
     d2 = SetMaterialParams(; Density = v2)
     r1 = (d1, d2)


### PR DESCRIPTION
### Whats the purpose of this PR?
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**
This PR adds:
- 3 different density laws: `RedlichKwong_Density`, `IdealGas_Density`, `ThreePhase_Density` with the latter using the RedlichKwong density. It matches the style of the MeltDensity and can be coupled with any other density structure in GP.
- `MeltingParam_Volatile`: Volatile-dependent silicic melting parameterisation used by Degruyter & Huber
(2014). The melt fraction can be computed by providing `mH2O` and `mCO2` in the args (for now)
- Solubility: `compute_dissolved` computes the dissolved H2O and CO2 which can then be added to the args for the melting

In general this PR adds new functionality to better capture the evolution of magmatic systems. 
Potential next steps are to decouple H2O in `DensityX` and `GiordanoMeltViscosity`  for some computations so we can have an evolving H2O content. This has not been implemented and requires a bit of thinking. 

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests were added, or old tests were updated
- [x] Are all lines covered by test? Code coverage should remain the same or increase
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [Runic Style](https://github.com/fredrikekre/Runic.jl)
