### PR TITLE
[BUGFIX] Restore physical 2D plastic flow derivatives

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoParams"
 uuid = "e018b62d-d9de-4a26-8697-af89c310ae38"
 authors = ["Boris Kaus <kaus@uni-mainz.de>, Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.18"
+version = "0.7.19"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Plasticity/DruckerPrager.jl
+++ b/src/Plasticity/DruckerPrager.jl
@@ -160,8 +160,8 @@ for t in (:NTuple, :SVector)
         ∂Q∂τxz(p::DruckerPrager, τij::$(t){6, T}) where {T} = τij[5] / second_invariant(τij)
         ∂Q∂τxy(p::DruckerPrager, τij::$(t){6, T}) where {T} = τij[6] / second_invariant(τij)
         ## 2D derivatives
-        ∂Q∂τxx(p::DruckerPrager, τij::$(t){3, T}) where {T} = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
-        ∂Q∂τyy(p::DruckerPrager, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        ∂Q∂τxx(p::DruckerPrager, τij::$(t){3, T}) where {T} = 0.5 * τij[1] / second_invariant(τij)
+        ∂Q∂τyy(p::DruckerPrager, τij::$(t){3, T}) where {T} = 0.5 * τij[2] / second_invariant(τij)
         ∂Q∂τxy(p::DruckerPrager, τij::$(t){3, T}) where {T} = τij[3] / second_invariant(τij)
     end
 end

--- a/src/Plasticity/DruckerPragerCap.jl
+++ b/src/Plasticity/DruckerPragerCap.jl
@@ -523,16 +523,16 @@ for t in (:NTuple, :SVector)
         end
 
         # --- 2D (3-component Voigt) ---
-        # diagonal components: τzz = -τxx - τyy (constraint) adds cross-terms to the gradient
+        # diagonal components of the physical tensor flow direction
         function ∂Q∂τxx(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}
             τII = second_invariant(τij)
             Aτ = ∂Q∂τII(p, τII; P = P, Pf = Pf, EII = EII, perturbation_C = perturbation_C)
-            return iszero(τII) ? zero(T) : Aτ * (τij[1] + 0.5 * τij[2]) / τII
+            return iszero(τII) ? zero(T) : Aτ * τij[1] / τII
         end
         function ∂Q∂τyy(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}
             τII = second_invariant(τij)
             Aτ = ∂Q∂τII(p, τII; P = P, Pf = Pf, EII = EII, perturbation_C = perturbation_C)
-            return iszero(τII) ? zero(T) : Aτ * (0.5 * τij[1] + τij[2]) / τII
+            return iszero(τII) ? zero(T) : Aτ * τij[2] / τII
         end
         # shear component: ∂Q/∂τij = 2Aτ * τij / τII
         function ∂Q∂τxy(p::DruckerPragerCap, τij::$(t){3, T}; P = zero(T), Pf = zero(T), EII = zero(T), perturbation_C = one(T), kwargs...) where {T}

--- a/src/Plasticity/DruckerPrager_regularised.jl
+++ b/src/Plasticity/DruckerPrager_regularised.jl
@@ -166,8 +166,8 @@ for t in (:NTuple, :SVector)
         ∂Q∂τxz(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[5] / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){6, T}) where {T} = τij[6] / second_invariant(τij)
         ## 2D derivatives
-        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
-        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        ∂Q∂τxx(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = 0.5 * τij[1] / second_invariant(τij)
+        ∂Q∂τyy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = 0.5 * τij[2] / second_invariant(τij)
         ∂Q∂τxy(::DruckerPrager_regularised, τij::$(t){3, T}) where {T} = τij[3] / second_invariant(τij)
     end
 end

--- a/test/test_Plasticity.jl
+++ b/test/test_Plasticity.jl
@@ -96,10 +96,10 @@ using LaTeXStrings
         @test num_alloc == 0
 
         # Test plastic potential derivatives
-        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
+        ## 2D physical tensor flow direction
         τij = (1.0, 2.0, 3.0)
-        fxx(τij) = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
-        fyy(τij) = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        fxx(τij) = 0.5 * τij[1] / second_invariant(τij)
+        fyy(τij) = 0.5 * τij[2] / second_invariant(τij)
         fxy(τij) = τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -113,11 +113,9 @@ using LaTeXStrings
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD — must agree with the analytical constrained gradient
-        Q = second_invariant # where second_invariant is a function
-        ad2 = ∂Q∂τ(Q, τij_tuple)
-        @test ad2 == (0.5, 0.625, 0.75)
-        @test collect(out1) ≈ collect(ad2)
+        # must agree with the equivalent explicit 3D tensor flow direction
+        out2_as_3D = ∂Q∂τ(p, (τij[1], τij[2], -τij[1] - τij[2], 0.0, 0.0, τij[3]))
+        @test all(isapprox.(out2, (out2_as_3D[1], out2_as_3D[2], out2_as_3D[6])))
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
@@ -260,10 +258,10 @@ using LaTeXStrings
         # @test num_alloc <= 32
 
         # Test plastic potential derivatives
-        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
+        ## 2D physical tensor flow direction
         τij = (1.0, 2.0, 3.0)
-        fxx(τij) = (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
-        fyy(τij) = (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        fxx(τij) = 0.5 * τij[1] / second_invariant(τij)
+        fyy(τij) = 0.5 * τij[2] / second_invariant(τij)
         fxy(τij) = τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -277,11 +275,9 @@ using LaTeXStrings
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD — must agree with the analytical constrained gradient
-        Q = second_invariant # where second_invariant is a function
-        ad2 = ∂Q∂τ(Q, τij_tuple)
-        @test ad2 == (0.5, 0.625, 0.75)
-        @test collect(out1) ≈ collect(ad2)
+        # must agree with the equivalent explicit 3D tensor flow direction
+        out2_as_3D = ∂Q∂τ(p, (τij[1], τij[2], -τij[1] - τij[2], 0.0, 0.0, τij[3]))
+        @test all(isapprox.(out2, (out2_as_3D[1], out2_as_3D[2], out2_as_3D[6])))
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
@@ -430,12 +426,12 @@ using LaTeXStrings
         @test num_alloc == 0
 
         # Test plastic potential derivatives
-        ## 2D — constrained gradient: τzz = -τxx - τyy is a function of stored components
+        ## 2D physical tensor flow direction
         τij = (1.0, 2.0, 3.0)
         τII_test = second_invariant(τij)
         dQτII = ∂Q∂τII(p, τII_test)
-        fxx(τij) = dQτII * (τij[1] + 0.5 * τij[2]) / second_invariant(τij)
-        fyy(τij) = dQτII * (0.5 * τij[1] + τij[2]) / second_invariant(τij)
+        fxx(τij) = dQτII * τij[1] / second_invariant(τij)
+        fyy(τij) = dQτII * τij[2] / second_invariant(τij)
         fxy(τij) = 2 * dQτII * τij[3] / second_invariant(τij)
         solution2D = [fxx(τij), fyy(τij), fxy(τij)]
 
@@ -445,11 +441,9 @@ using LaTeXStrings
         @test out2 == Tuple(solution2D)
         @test compute_plasticpotentialDerivative(p, τij_tuple) == ∂Q∂τ(p, τij_tuple)
 
-        # using AD — must agree with analytical constrained gradient scaled by Aτ
-        Q = second_invariant # where second_invariant is a function
-        ad2 = ∂Q∂τ(Q, τij_tuple)
-        @test ad2 == (0.5, 0.625, 0.75)
-        @test all(isapprox.(dQτII .* collect(ad2), [out2[1], out2[2], out2[3] / 2]; rtol = 1.0e-5))
+        # must agree with the equivalent explicit 3D tensor flow direction
+        out2_as_3D = ∂Q∂τ(p, (τij[1], τij[2], -τij[1] - τij[2], 0.0, 0.0, τij[3]))
+        @test all(isapprox.(out2, (out2_as_3D[1], out2_as_3D[2], out2_as_3D[6])))
 
         ## 3D
         τij = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
@@ -608,9 +602,9 @@ using LaTeXStrings
         @test ∂Q∂τ(Q, [1.0, 2.0, 2.0]) ≈ [1 / 3, 2 / 3, 2 / 3] rtol = 1.0e-9
         # 3-arg (args, kwargs) form + the MaterialParams plasticity dispatch
         τ = @SVector [1.0, 2.0, 3.0]
-        @test ∂Q∂τ(p, τ, (;)) ≈ [0.5, 0.625, 0.75] rtol = 1.0e-9
+        @test ∂Q∂τ(p, τ, (;)) ≈ [0.125, 0.25, 0.75] rtol = 1.0e-9
         mp = SetMaterialParams(; Phase = 1, Plasticity = DruckerPrager(; C = 1.0e6))
-        @test ∂Q∂τ(mp, τ) ≈ [0.5, 0.625, 0.75] rtol = 1.0e-9
+        @test ∂Q∂τ(mp, τ) ≈ [0.125, 0.25, 0.75] rtol = 1.0e-9
     end
 
 end


### PR DESCRIPTION
Fixes #341.

## What went wrong

The formulas introduced in #335 are the correct derivatives of `second_invariant` with respect to the two independent coordinates in the compressed 2D representation, where `τzz = -τxx - τyy`:

- `gx = qxx - qzz`
- `gy = qyy - qzz`

They are therefore constrained-coordinate covector components. The constitutive routines consume `∂Q∂τ` as the physical tensor components `qxx` and `qyy` of the plastic flow direction. Using `gx` and `gy` directly in the stress correction makes the implicit `τzz` correction three times the physical radial-return value and invalidates the plastic-multiplier denominator. In JustRelax DYREL models this can overshoot the yield surface and produce runaway stress buildup.

## Fix

- Restore the physical 2D tensor-flow components for `DruckerPrager`, `DruckerPrager_regularised`, and `DruckerPragerCap`.
- Replace the compressed-coordinate ForwardDiff assertions with constitutive regression tests that compare each 2D flow direction against the equivalent explicit 3D deviatoric tensor `(τxx, τyy, -τxx-τyy, 0, 0, τxy)`.

This preserves the intended constitutive contract: the compact 2D storage changes how `τII` is evaluated, but it does not change the physical tensor components returned for the flow rule.

## Verification

- GeoParams `test/test_Plasticity.jl`: 135/135 passed.
- JustRelax `test_dyrel_kernels`: 19/19 passed using this developed GeoParams checkout.
- `git diff --check` passes.